### PR TITLE
fix: update delete account email security warning

### DIFF
--- a/apps/backend/src/emails/delete-account.tsx
+++ b/apps/backend/src/emails/delete-account.tsx
@@ -105,8 +105,9 @@ const DeleteAccountEmail: React.FC<DeleteAccountEmailProps> = ({
 						</Text>
 					</Section>
 					<Text style={text}>
-						If you didn't request this account deletion, please ignore this
-						email. Your account will remain active and secure.
+						If you didn't request this account deletion, your account may be
+						compromised. Please <strong>immediately</strong> secure your account
+						by changing your password.
 					</Text>
 					<Text style={paragraph}>
 						Best,


### PR DESCRIPTION
Change the message when user didn't request deletion from "ignore this email" to warn about potential account compromise and advise immediate password change.