### PR TITLE
fix: prevent authenticated user from accessing signup/signin

### DIFF
--- a/apps/frontend/src/routes/signin.tsx
+++ b/apps/frontend/src/routes/signin.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { z } from "zod";
 import { SignInForm } from "@/components/auth/forms/signin-form";
@@ -8,6 +8,11 @@ export const Route = createFileRoute("/signin")({
 		redirect: z.string().optional().catch(""),
 		error: z.string().optional(),
 	}),
+	beforeLoad: async ({ context }) => {
+		if (context.session?.user) {
+			throw redirect({ to: "/dashboard" });
+		}
+	},
 	component: SigninPage,
 });
 

--- a/apps/frontend/src/routes/signup.tsx
+++ b/apps/frontend/src/routes/signup.tsx
@@ -1,7 +1,12 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { SignUpForm } from "@/components/auth/forms/signup-form";
 
 export const Route = createFileRoute("/signup")({
+	beforeLoad: async ({ context }) => {
+		if (context.session?.user) {
+			throw redirect({ to: "/dashboard" });
+		}
+	},
 	component: SignUpPage,
 });
 


### PR DESCRIPTION
auth users will be redirect to /dashboard if they try to access signin/signup pages