### PR TITLE
feat: add cache for get responses

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -10,7 +10,7 @@ import { connection } from "#lib/database";
 import env from "#lib/env";
 import { logger } from "#lib/logger";
 import { serveInternalServerError } from "#lib/responses/error";
-import { cacheMiddleware } from "#web/middlewares/cache";
+import { cache, cacheMiddleware } from "#web/middlewares/cache";
 import { sessionMiddleware } from "#web/middlewares/session";
 import authRoutes from "#web/routes/auth";
 import certificationRoutes from "#web/routes/certification";
@@ -27,10 +27,6 @@ import searchRoutes from "#web/routes/search";
 import trendingRoutes from "#web/routes/trending";
 import tvRoutes from "#web/routes/tv";
 import watchProvidersRoutes from "#web/routes/watch-providers";
-
-declare global {
-	var __routesShown: boolean | undefined;
-}
 
 const app = new Hono<{
 	Variables: {
@@ -91,12 +87,10 @@ app.onError((err, c) => {
 });
 
 if (env.NODE_ENV === "development") {
-	if (!global.__routesShown) {
-		console.log("Available routes:");
-		showRoutes(app);
-		global.__routesShown = true;
-	}
+	await cache.flush();
+	logger.info("Cache flushed on dev startup");
 }
+
 const port = Number(env.PORT);
 logger.info(`Server is running on port ${port} and env: ${env.NODE_ENV}`);
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -10,6 +10,7 @@ import { connection } from "#lib/database";
 import env from "#lib/env";
 import { logger } from "#lib/logger";
 import { serveInternalServerError } from "#lib/responses/error";
+import { cacheMiddleware } from "#web/middlewares/cache";
 import { sessionMiddleware } from "#web/middlewares/session";
 import authRoutes from "#web/routes/auth";
 import certificationRoutes from "#web/routes/certification";
@@ -50,7 +51,6 @@ app.use(
 	}),
 );
 
-const api = new Hono();
 app.use(httpLogger());
 app.use(trimTrailingSlash());
 app.use("/assets/*", serveStatic({ root: "./src" }));
@@ -67,7 +67,9 @@ const pingDB = async () => {
 pingDB();
 
 app.use("*", sessionMiddleware);
+const api = new Hono();
 api.route("/auth", authRoutes);
+api.use("*", cacheMiddleware);
 api.route("/movies", movieRoutes);
 api.route("/tv", tvRoutes);
 api.route("/person", personRoutes);

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -6,11 +6,12 @@ import { showRoutes } from "hono/dev";
 import { logger as httpLogger } from "hono/logger";
 import { trimTrailingSlash } from "hono/trailing-slash";
 import type { auth } from "#lib/auth";
+import { cacheClient } from "#lib/cache-client";
 import { connection } from "#lib/database";
 import env from "#lib/env";
 import { logger } from "#lib/logger";
 import { serveInternalServerError } from "#lib/responses/error";
-import { cache, cacheMiddleware } from "#web/middlewares/cache";
+import { cacheMiddleware } from "#web/middlewares/cache";
 import { sessionMiddleware } from "#web/middlewares/session";
 import authRoutes from "#web/routes/auth";
 import certificationRoutes from "#web/routes/certification";
@@ -27,6 +28,10 @@ import searchRoutes from "#web/routes/search";
 import trendingRoutes from "#web/routes/trending";
 import tvRoutes from "#web/routes/tv";
 import watchProvidersRoutes from "#web/routes/watch-providers";
+
+declare global {
+	var __cacheFlushed: boolean | undefined;
+}
 
 const app = new Hono<{
 	Variables: {
@@ -87,8 +92,11 @@ app.onError((err, c) => {
 });
 
 if (env.NODE_ENV === "development") {
-	await cache.flush();
-	logger.info("Cache flushed on dev startup");
+	if (!global.__cacheFlushed) {
+		await cacheClient.flush();
+		logger.info("Cache flushed on dev startup");
+		global.__cacheFlushed = true;
+	}
 }
 
 const port = Number(env.PORT);

--- a/apps/backend/src/lib/cache-client.ts
+++ b/apps/backend/src/lib/cache-client.ts
@@ -1,0 +1,41 @@
+import { RedisClient } from "bun";
+import env from "./env";
+import { logger } from "./logger";
+
+const cacheRedis = new RedisClient(`${env.REDIS_URL}/1`);
+
+export const cacheClient = {
+	get: async (key: string): Promise<string | null> => {
+		try {
+			const value = await cacheRedis.get(key);
+			return value as string | null;
+		} catch (error) {
+			logger.error(error, `Cache get error for key ${key}`);
+			return null;
+		}
+	},
+	set: async (key: string, value: string, ttl?: number): Promise<void> => {
+		try {
+			await cacheRedis.set(key, value);
+			if (ttl) {
+				await cacheRedis.expire(key, ttl);
+			}
+		} catch (error) {
+			logger.error(error, `Cache set error for key ${key}`);
+		}
+	},
+	delete: async (key: string): Promise<void> => {
+		try {
+			await cacheRedis.del(key);
+		} catch (error) {
+			logger.error(error, `Cache delete error for key ${key}`);
+		}
+	},
+	flush: async (): Promise<void> => {
+		try {
+			await cacheRedis.send("FLUSHDB", []);
+		} catch (error) {
+			logger.error(error, "Cache flush error");
+		}
+	},
+};

--- a/apps/backend/src/web/middlewares/cache.ts
+++ b/apps/backend/src/web/middlewares/cache.ts
@@ -1,0 +1,42 @@
+import { redis } from "bun";
+import type { Context, Next } from "hono";
+import { logger } from "#lib/logger";
+
+const cache = {
+	get: async (key: string) => {
+		return await redis.get(key);
+	},
+	set: async (key: string, value: string, ttl?: number) => {
+		await redis.set(key, value);
+		if (ttl) {
+			await redis.expire(key, ttl);
+		}
+	},
+	delete: async (key: string) => {
+		await redis.del(key);
+	},
+};
+
+export const cacheMiddleware = async (c: Context, next: Next) => {
+	if (c.req.method !== "GET") {
+		return next();
+	}
+
+	const queryString = new URLSearchParams(c.req.query()).toString();
+	const key = `cache:${c.req.path}${queryString ? `:${queryString}` : ""}`;
+
+	const cached = await cache.get(key);
+	if (cached) {
+		logger.info(`Cache hit: ${key}`);
+		return c.json(JSON.parse(cached as string));
+	}
+
+	await next();
+
+	const res = c.res.clone();
+	if (res.ok && res.headers.get("content-type")?.includes("application/json")) {
+		const body = await res.json();
+		await cache.set(key, JSON.stringify(body), 28800);
+		logger.info(`Cache set: ${key}`);
+	}
+};

--- a/apps/backend/src/web/middlewares/cache.ts
+++ b/apps/backend/src/web/middlewares/cache.ts
@@ -1,20 +1,21 @@
-import { redis } from "bun";
 import type { Context, Next } from "hono";
 import { logger } from "#lib/logger";
+import { cacheClient } from "../../lib/cache-client";
 
-const cache = {
-	get: async (key: string) => {
-		return await redis.get(key);
-	},
-	set: async (key: string, value: string, ttl?: number) => {
-		await redis.set(key, value);
-		if (ttl) {
-			await redis.expire(key, ttl);
-		}
-	},
-	delete: async (key: string) => {
-		await redis.del(key);
-	},
+const MAX_CACHE_SIZE = 5 * 1024 * 1024;
+const DEFAULT_TTL = 28800;
+
+const parseCacheControlMaxAge = (
+	cacheControl: string | undefined | null,
+): number | null => {
+	if (!cacheControl) return null;
+
+	const maxAgeMatch = cacheControl.match(/max-age=(\d+)/);
+	if (maxAgeMatch) {
+		return Number.parseInt(maxAgeMatch[1], 10);
+	}
+
+	return null;
 };
 
 export const cacheMiddleware = async (c: Context, next: Next) => {
@@ -22,21 +23,53 @@ export const cacheMiddleware = async (c: Context, next: Next) => {
 		return next();
 	}
 
+	const cacheControl = c.req.header("Cache-Control");
+	if (
+		cacheControl?.includes("no-cache") ||
+		cacheControl?.includes("no-store")
+	) {
+		return next();
+	}
+
 	const queryString = new URLSearchParams(c.req.query()).toString();
 	const key = `cache:${c.req.path}${queryString ? `:${queryString}` : ""}`;
 
-	const cached = await cache.get(key);
+	const cached = await cacheClient.get(key);
 	if (cached) {
 		logger.info(`Cache hit: ${key}`);
-		return c.json(JSON.parse(cached as string));
+		return c.json(JSON.parse(cached));
 	}
 
 	await next();
 
+	if (!c.res) {
+		return;
+	}
+
 	const res = c.res.clone();
 	if (res.ok && res.headers.get("content-type")?.includes("application/json")) {
-		const body = await res.json();
-		await cache.set(key, JSON.stringify(body), 28800);
-		logger.info(`Cache set: ${key}`);
+		try {
+			const body = await res.json();
+			const bodyString = JSON.stringify(body);
+
+			const size = new Blob([bodyString]).size;
+			if (size > MAX_CACHE_SIZE) {
+				logger.info(
+					`Response too large to cache: ${key} (${(size / 1024 / 1024).toFixed(2)}MB)`,
+				);
+				return;
+			}
+
+			const responseCacheControl = res.headers.get("Cache-Control");
+			const maxAge = parseCacheControlMaxAge(responseCacheControl);
+			const ttl = maxAge ?? DEFAULT_TTL;
+
+			await cacheClient.set(key, bodyString, ttl);
+			const ttlDisplay =
+				ttl >= 3600 ? `${Math.round(ttl / 3600)}h` : `${Math.round(ttl / 60)}m`;
+			logger.info(`Cache set: ${key} (TTL: ${ttlDisplay})`);
+		} catch (error) {
+			logger.error(error, `Failed to cache response for ${key}`);
+		}
 	}
 };

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,20 +1,25 @@
 {
 	"compilerOptions": {
 		"strict": true,
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"target": "esnext",
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
 		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,
+		"baseUrl": "./",
+		"outDir": "./dist",
 		"paths": {
-			"#lib/*": ["./src/lib/*"],
-			"#emails/*": ["./src/emails/*"],
-			"#db/schemas/*": ["./src/db/schemas/*"],
-			"#middlewares/*": ["./src/middlewares/*"],
-			"#tasks/*": ["./src/tasks/*"],
-			"#utils/*": ["./src/utils/*"],
-			"#web/*": ["./src/web/*"],
-			"#types/*": ["./src/types/*"],
-			"#validators/*": ["./src/web/validators/*"]
+			"#lib/*": ["src/lib/*"],
+			"#emails/*": ["src/emails/*"],
+			"#db/schemas/*": ["src/db/schemas/*"],
+			"#middlewares/*": ["src/middlewares/*"],
+			"#tasks/*": ["src/tasks/*"],
+			"#utils/*": ["src/utils/*"],
+			"#web/*": ["src/web/*"],
+			"#types/*": ["src/types/*"],
+			"#validators/*": ["src/web/validators/*"]
 		}
 	}
 }


### PR DESCRIPTION
- cache api response for 8h unless a specific ttl is present in CacheControl headers
- auth cache stays in a separate redis db