### PR TITLE
fix: add a max length for default shown biography

### DIFF
--- a/apps/frontend/src/components/person/person-biography.tsx
+++ b/apps/frontend/src/components/person/person-biography.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { Button } from "../ui/button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "../ui/collapsible";
+
+interface PersonBiography {
+	biography: string;
+}
+
+export function PersonBiography({ biography }: PersonBiography) {
+	const [isCollapsibleOpen, setIsCollapsibleOpen] = useState(false);
+
+	if (!biography) {
+		return <p></p>;
+	}
+
+	const maxInitialLength = 400;
+	const lines = biography.split("\n");
+	const [firstLine, ...rest] = lines;
+	const remainingText = rest.join("\n");
+
+	const needsCollapse = remainingText || firstLine.length > maxInitialLength;
+
+	if (!needsCollapse) {
+		return <p>{firstLine}</p>;
+	}
+
+	let displayText: string;
+	let hiddenText: string;
+
+	if (remainingText) {
+		displayText = firstLine;
+		hiddenText = remainingText;
+	} else {
+		const textUpToLimit = firstLine.slice(0, maxInitialLength);
+		const lastSentenceEnd = Math.max(
+			textUpToLimit.lastIndexOf(". "),
+			textUpToLimit.lastIndexOf("! "),
+			textUpToLimit.lastIndexOf("? "),
+		);
+
+		if (lastSentenceEnd > 0) {
+			displayText = firstLine.slice(0, lastSentenceEnd + 1);
+			hiddenText = firstLine.slice(lastSentenceEnd + 1).trim();
+		} else {
+			displayText = firstLine.slice(0, maxInitialLength);
+			hiddenText = firstLine.slice(maxInitialLength);
+		}
+	}
+
+	return (
+		<>
+			<p className="whitespace-pre-line">{displayText}</p>
+			<Collapsible open={isCollapsibleOpen} onOpenChange={setIsCollapsibleOpen}>
+				<CollapsibleTrigger asChild>
+					<Button variant="link" size="sm" className="p-0">
+						{isCollapsibleOpen ? "Show less" : "Show more"}
+					</Button>
+				</CollapsibleTrigger>
+				<CollapsibleContent>
+					<p className="whitespace-pre-line">{hiddenText}</p>
+				</CollapsibleContent>
+			</Collapsible>
+		</>
+	);
+}

--- a/apps/frontend/src/components/person/person-details.tsx
+++ b/apps/frontend/src/components/person/person-details.tsx
@@ -1,5 +1,4 @@
 import { ArrowLeft } from "lucide-react";
-import { useState } from "react";
 import type { Schemas } from "shared";
 import fallbackPoster from "@/assets/user-placeholder.jpg";
 import { calculateAge } from "@/utils/calculate-age";
@@ -19,11 +18,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "../ui/card";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "../ui/collapsible";
+import { PersonBiography } from "./person-biography";
 
 interface PersonDetailsViewProps {
 	person: Schemas.PersonDetailsWithCombinedCreditsAndSocials | undefined;
@@ -38,8 +33,6 @@ export const PersonDetailsView = ({
 	isError,
 	onBack,
 }: PersonDetailsViewProps) => {
-	const [isCollapsibleOpen, setIsCollapsibleOpen] = useState(false);
-
 	if (isLoading) {
 		return <LoadingCentered />;
 	}
@@ -148,44 +141,13 @@ export const PersonDetailsView = ({
 						</CardContent>
 					</Card>
 
-					<Card className="relative overflow-hidden border-none">
+					<Card className="relative overflow-hidden border-none justify-center">
 						<CardHeader className="text-foreground">
 							<CardTitle>Biography</CardTitle>
 						</CardHeader>
 						<CardContent className="text-muted-foreground gap-4">
-							{person.biography ? (
-								(() => {
-									const [firstLine, ...rest] = person.biography.split("\n");
-									const remainingText = rest.join("\n");
-
-									if (!remainingText) {
-										return <p>{firstLine}</p>;
-									}
-
-									return (
-										<>
-											<p>{firstLine}</p>
-											<Collapsible
-												open={isCollapsibleOpen}
-												onOpenChange={setIsCollapsibleOpen}
-											>
-												<CollapsibleTrigger asChild>
-													<Button variant="link" size="sm" className="p-0">
-														{isCollapsibleOpen ? "Show less" : "Show more"}
-													</Button>
-												</CollapsibleTrigger>
-												<CollapsibleContent>
-													<p className="whitespace-pre-line">{remainingText}</p>
-												</CollapsibleContent>
-											</Collapsible>
-										</>
-									);
-								})()
-							) : (
-								<p>No biography found for {person.name}.</p>
-							)}
+							<PersonBiography biography={person.biography} />
 						</CardContent>
-
 						{person.place_of_birth ? (
 							<CardFooter>
 								<div className="flex flex-wrap gap-2">


### PR DESCRIPTION
- when a biography has no escape sequences, add a max length to show only a part of the text