### PR TITLE
feat: improve mobile navigation on mobile

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -14,7 +14,7 @@
 		"machine-translate": "inlang machine translate --project project.inlang"
 	},
 	"dependencies": {
-		"@base-ui/react": "^1.1.0",
+		"@base-ui/react": "^1.3.0",
 		"@dnd-kit/core": "^6.3.1",
 		"@dnd-kit/modifiers": "^9.0.0",
 		"@dnd-kit/sortable": "^10.0.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -54,6 +54,7 @@
 		"tailwind-merge": "^3.4.0",
 		"tailwindcss": "^4.1.13",
 		"tw-animate-css": "^1.3.8",
+		"vaul": "^1.1.2",
 		"zod": "^4.1.8"
 	},
 	"devDependencies": {

--- a/apps/frontend/src/components/auth/forms/signup-form.tsx
+++ b/apps/frontend/src/components/auth/forms/signup-form.tsx
@@ -246,14 +246,16 @@ export function SignUpForm() {
 													</Tooltip>
 												</TooltipProvider>
 											</div>
-											<Input
-												id={`${id}-password`}
-												type="password"
-												autoComplete="new-password"
-												minLength={8}
-												required
-												{...field}
-											/>
+											<FieldContent>
+												<Input
+													id={`${id}-password`}
+													type="password"
+													autoComplete="new-password"
+													minLength={8}
+													required
+													{...field}
+												/>
+											</FieldContent>
 											<FieldError />
 										</Field>
 									)}

--- a/apps/frontend/src/components/header.tsx
+++ b/apps/frontend/src/components/header.tsx
@@ -3,7 +3,6 @@ import {
 	IconMovie,
 	IconSearch,
 	IconSmartHome,
-	IconUser,
 } from "@tabler/icons-react";
 import { useRouteContext } from "@tanstack/react-router";
 import { useState } from "react";
@@ -85,11 +84,11 @@ export default function Header() {
 			icon: <IconSearch className="h-6 w-6" />,
 			onClick: () => setSearchOpen(true),
 		},
-		{
-			name: m.header_link_profile(),
-			link: authData ? `/user/${authData?.user.name}` : `/signin`,
-			icon: <IconUser className="h-6 w-6" />,
-		},
+		// {
+		// 	name: m.header_link_profile(),
+		// 	link: authData ? `/user/${authData?.user.name}` : `/signin`,
+		// 	icon: <IconUser className="h-6 w-6" />,
+		// },
 	];
 
 	return (

--- a/apps/frontend/src/components/header.tsx
+++ b/apps/frontend/src/components/header.tsx
@@ -8,6 +8,7 @@ import {
 import { useRouteContext } from "@tanstack/react-router";
 import { useState } from "react";
 import { LocaleRegionDropdown } from "@/components/locale-region-dropdown";
+import { ProfileDrawer } from "@/components/profile-drawer";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { SearchCommand } from "@/components/search/search-command";
 import { MobileBottomNav, MobileTopBar } from "@/components/ui/mobile-navbar";
@@ -121,22 +122,21 @@ export default function Header() {
 
 			{/* Mobile Top Bar */}
 			<MobileTopBar
-				logo={<MobileNavbarLogo />}
-				dropdown={
-					<div className="flex items-center gap-3">
-						<LocaleRegionDropdown />
-
-						{authData ? null : (
-							<NavbarButton
-								variant="primary"
-								to="/signin"
-								className="text-xs py-2.5 px-2"
-							>
-								{m.header_btn_sign_in()}
-							</NavbarButton>
-						)}
-					</div>
+				left={
+					authData ? (
+						<ProfileDrawer />
+					) : (
+						<NavbarButton
+							variant="primary"
+							to="/signin"
+							className="text-xs py-2.5 px-2"
+						>
+							{m.header_btn_sign_in()}
+						</NavbarButton>
+					)
 				}
+				center={<MobileNavbarLogo />}
+				right={<LocaleRegionDropdown />}
 			/>
 
 			{/* Mobile Bottom Navigation */}

--- a/apps/frontend/src/components/lists/custom-lists/details/list-media-details-card.tsx
+++ b/apps/frontend/src/components/lists/custom-lists/details/list-media-details-card.tsx
@@ -52,15 +52,15 @@ export const ListMediaDetailsCard = ({
 
 			<div className="flex-1 flex flex-col gap-2">
 				<div className="flex justify-between w-full">
-					<div className="flex items-baseline gap-2">
-						<Link to={linkTo} className="text-lg font-semibold">
+					<div className="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-2">
+						<Link to={linkTo} className="text-base md:text-lg font-semibold">
 							{item.title}
 						</Link>
 						{year ? (
 							<span className="text-sm text-muted-foreground">{year}</span>
 						) : null}
 					</div>
-					<div>
+					<div className="hidden sm:block">
 						{item.mediaType === "movie" ? <MovieBadge /> : <TvShowBadge />}
 					</div>
 				</div>

--- a/apps/frontend/src/components/lists/custom-lists/list-search-add.tsx
+++ b/apps/frontend/src/components/lists/custom-lists/list-search-add.tsx
@@ -136,7 +136,9 @@ function SearchResultContent({ item }: SearchResultContentProps) {
 							})}
 						</span>
 					)}
-					<MovieBadge />
+					<div className="hidden md:flex">
+						<MovieBadge />
+					</div>
 				</div>
 			</div>
 		);
@@ -158,7 +160,9 @@ function SearchResultContent({ item }: SearchResultContentProps) {
 							{formatDate(tv.first_air_date, localeRegion, { year: "numeric" })}
 						</span>
 					)}
-					<TvShowBadge />
+					<div className="hidden md:flex">
+						<TvShowBadge />
+					</div>
 				</div>
 			</div>
 		);

--- a/apps/frontend/src/components/lists/watchlist/watchlist-media-card.tsx
+++ b/apps/frontend/src/components/lists/watchlist/watchlist-media-card.tsx
@@ -4,7 +4,6 @@ import { MovieBadge } from "@/components/badges/movie-badge";
 import { TvShowBadge } from "@/components/badges/tv-badge";
 import { getTmdbImageUrl } from "@/utils/utils";
 import { ListDropdown } from "../media-actions/list-dropdown";
-import { WatchlistToggleButton } from "./watchlist-toggle-button";
 
 interface WatchlistMediaCardProps {
 	item: {
@@ -57,8 +56,7 @@ export const WatchlistMediaCard = ({
 					/>
 					<div className="absolute inset-x-0 top-0 h-24 bg-linear-to-b from-black/90 to-transparent" />
 					<div className="absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-black/90" />
-					<div className="w-full absolute top-2 px-2 flex items-center justify-between z-10">
-						<WatchlistToggleButton size={5} {...mediaProps} />
+					<div className="w-full absolute top-2 flex items-center justify-end z-10 pr-2">
 						{item.mediaType === "movie" ? (
 							<MovieBadge minWidth={8} />
 						) : (

--- a/apps/frontend/src/components/locale-region-dropdown.tsx
+++ b/apps/frontend/src/components/locale-region-dropdown.tsx
@@ -1,6 +1,8 @@
-import { IconLanguage } from "@tabler/icons-react";
+import { IconCheck, IconLanguage } from "@tabler/icons-react";
 import { useAtomValue, useSetAtom } from "jotai";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Drawer, DrawerContent, DrawerTrigger } from "@/components/ui/drawer";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -11,6 +13,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useMediaQuery } from "@/integrations/media-query";
 import { localeAtom, setLocaleAtom } from "@/lib/atoms/locale";
 import { regionAtom, SUPPORTED_REGIONS } from "@/lib/atoms/region";
 import { m } from "@/paraglide/messages";
@@ -33,11 +36,82 @@ const getRegionName = (region: string): string => {
 	}
 };
 
+const LocaleRegionContent = () => {
+	const locale = useAtomValue(localeAtom);
+	const region = useAtomValue(regionAtom);
+	const changeLocale = useSetAtom(setLocaleAtom);
+	const changeRegion = useSetAtom(regionAtom);
+
+	return (
+		<div className="space-y-4">
+			<div>
+				<h3 className="mb-2 font-medium">{m.locale_dropdown_label()}</h3>
+				<div className="space-y-1">
+					{locales.map((tag) => (
+						<Button
+							key={tag}
+							variant={locale === tag ? "secondary" : "ghost"}
+							className="w-full justify-start"
+							onClick={() => changeLocale(tag)}
+						>
+							<span className="flex-1 text-left">{tag.toUpperCase()}</span>
+							{locale === tag && <IconCheck className="h-4 w-4" />}
+						</Button>
+					))}
+				</div>
+			</div>
+			<div className="h-px bg-border" />
+			<div>
+				<h3 className="mb-2 font-medium">{m.region_dropdown_label()}</h3>
+				<div className="space-y-1">
+					{SUPPORTED_REGIONS.map((reg) => (
+						<Button
+							key={reg}
+							variant={region === reg ? "secondary" : "ghost"}
+							className="w-full justify-start"
+							onClick={() => changeRegion(reg)}
+						>
+							<span className="flex-1 text-left">{getRegionName(reg)}</span>
+							{region === reg && <IconCheck className="h-4 w-4" />}
+						</Button>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+};
+
 export const LocaleRegionDropdown = () => {
 	const locale = useAtomValue(localeAtom);
 	const region = useAtomValue(regionAtom);
 	const changeLocale = useSetAtom(setLocaleAtom);
 	const changeRegion = useSetAtom(regionAtom);
+	const [open, setOpen] = useState(false);
+	const isMobile = useMediaQuery("(max-width: 768px)");
+
+	if (isMobile) {
+		return (
+			<Drawer open={open} onOpenChange={setOpen} swipeDirection="up">
+				<DrawerTrigger
+					render={(props) => (
+						<Button
+							{...props}
+							variant="ghost"
+							size="icon"
+							aria-label="language"
+						>
+							<IconLanguage />
+						</Button>
+					)}
+				/>
+				<DrawerContent>
+					<div className="p-4">
+						<LocaleRegionContent />
+					</div>
+				</DrawerContent>
+			</Drawer>
+		);
+	}
 
 	return (
 		<DropdownMenu>

--- a/apps/frontend/src/components/locale-region-dropdown.tsx
+++ b/apps/frontend/src/components/locale-region-dropdown.tsx
@@ -122,7 +122,7 @@ export const LocaleRegionDropdown = () => {
 					</Button>
 				}
 			/>
-			<DropdownMenuContent align="end">
+			<DropdownMenuContent align="end" className="w-40">
 				<DropdownMenuGroup>
 					<DropdownMenuLabel>{m.locale_dropdown_label()}</DropdownMenuLabel>
 					<DropdownMenuRadioGroup value={locale} onValueChange={changeLocale}>

--- a/apps/frontend/src/components/medias/media-portrait-image.tsx
+++ b/apps/frontend/src/components/medias/media-portrait-image.tsx
@@ -4,12 +4,12 @@ import type { Schemas } from "shared";
 import fallbackPoster from "@/assets/media-image-placeholder.jpg";
 import { WatchProvidersSection } from "@/components/watch-providers/watch-providers-section";
 import { regionAtom } from "@/lib/atoms/region";
-import { getTmdbImageUrl } from "@/utils/utils";
+import { getTmdbImageUrl, type ImageSize } from "@/utils/utils";
 
 interface MediaPortraitImageProps {
 	imagePath: string | null;
 	alt: string;
-	imageSize?: "w500" | "original";
+	imageSize?: ImageSize;
 	watchProviders?: Schemas.WatchProviders;
 }
 

--- a/apps/frontend/src/components/medias/media-portrait-image.tsx
+++ b/apps/frontend/src/components/medias/media-portrait-image.tsx
@@ -34,7 +34,7 @@ export function MediaPortraitImage({
 			<img
 				src={imageUrl ?? fallbackPoster}
 				alt={alt}
-				className="aspect-2/3 w-full max-h-90 rounded-lg shadow-lg xl:max-h-[450px]"
+				className="aspect-2/3 w-full max-h-72 lg:max-h-90 rounded-lg shadow-lg xl:max-h-[450px]"
 				onError={handleImageError}
 			/>
 

--- a/apps/frontend/src/components/movies/movie-details.tsx
+++ b/apps/frontend/src/components/movies/movie-details.tsx
@@ -69,12 +69,12 @@ export function MovieDetailView({
 	const hasDifferentTitle =
 		movie.original_title.toLowerCase() !== movie.title.toLowerCase();
 
-	const backgroundImage = getTmdbImageUrl(movie.backdrop_path, "original")
+	const backgroundImage = getTmdbImageUrl(movie.backdrop_path, "original");
 
 	return (
 		<>
 			<MediaBackgroundImage backgroundImage={backgroundImage} />
-			<div className="container pt-10 lg:pt-30">
+			<div className="container pt-3 md:pt-10 lg:pt-30">
 				<BackButton />
 
 				<div className="grid lg:grid-cols-[auto_1fr] gap-2 lg:gap-4 pt-2 justify-items-center">
@@ -99,11 +99,11 @@ export function MovieDetailView({
 								<div className="flex flex-col md:flex-row md:justify-between md:items-start gap-2 px-0.5 py-0.5">
 									<div className="flex flex-col gap-2">
 										<div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-											<h1 className="text-4xl font-bold leading-relaxed">
+											<h1 className="text-2xl lg:text-4xl font-bold leading-relaxed">
 												{movie.title}
 											</h1>
 											{hasDifferentTitle ? (
-												<p className="text-foreground text-lg font-bold italic">
+												<p className="text-foreground text-base lg:text-xl font-bold italic">
 													— {movie.original_title}
 												</p>
 											) : null}
@@ -122,7 +122,7 @@ export function MovieDetailView({
 
 										<div className="flex flex-col gap-1">
 											{movie.tagline ? (
-												<p className="font-bold italic text-lg">
+												<p className="font-bold italic text-base lg:text-lg">
 													{movie.tagline}
 												</p>
 											) : null}
@@ -137,7 +137,7 @@ export function MovieDetailView({
 															to="/person/$personId"
 															params={{ personId: person.id.toString() }}
 														>
-															<h3 className="font-semibold text-lg whitespace-nowrap">
+															<h3 className="font-semibold text-base lg:text-lg whitespace-nowrap">
 																{person.name}
 															</h3>
 														</Link>
@@ -211,6 +211,7 @@ export function MovieDetailView({
 								<Link
 									to="/movies/$movieId/credits"
 									params={{ movieId: movie.id.toString() }}
+									className="text-sm md:text-lg"
 								>
 									{m.link_text_full_credits()}
 								</Link>

--- a/apps/frontend/src/components/profile-drawer.tsx
+++ b/apps/frontend/src/components/profile-drawer.tsx
@@ -1,0 +1,203 @@
+import {
+	IconAdjustmentsHorizontal,
+	IconBrandGithub,
+	IconClockBolt,
+	IconExternalLink,
+	IconHeart,
+	IconHistory,
+	IconLifebuoy,
+	IconList,
+	IconLogout,
+	IconUser,
+} from "@tabler/icons-react";
+import {
+	useNavigate,
+	useRouteContext,
+	useRouter,
+} from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+	Drawer,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerTrigger,
+} from "@/components/ui/drawer";
+import { Separator } from "@/components/ui/separator";
+import { queryClient } from "@/integrations/tanstack-query/root-provider";
+import { authClient } from "@/lib/auth-client";
+import { sessionQueryOptions } from "@/lib/queries/session";
+import { m } from "@/paraglide/messages";
+import { ProfileTriggerButton } from "./profile-trigger-button";
+
+export function ProfileDrawer() {
+	const { authData } = useRouteContext({ from: "__root__" });
+	const navigate = useNavigate();
+	const router = useRouter();
+	const [isOpen, setIsOpen] = useState(false);
+
+	if (!authData) return null;
+	const username = authData.user.name;
+	const displayName = authData.user.displayName;
+	const image = authData.user.image;
+
+	const logout = async () => {
+		await authClient.signOut();
+
+		queryClient.setQueryData(sessionQueryOptions.queryKey, null);
+		queryClient.removeQueries({ queryKey: ["accounts"] });
+
+		toast.success(m.toast_success_logout());
+
+		await router.navigate({ to: "/" });
+	};
+
+	return (
+		<Drawer swipeDirection="left" open={isOpen} onOpenChange={setIsOpen}>
+			<DrawerTrigger
+				render={(props) => (
+					<ProfileTriggerButton
+						{...props}
+						username={username}
+						displayName={displayName}
+						image={image}
+						showUsername={false}
+						className="border-0 border-none ring-0 p-0"
+					/>
+				)}
+			/>
+			<DrawerContent className="focus:outline-none focus-visible:outline-none *:focus:outline-none">
+				<DrawerHeader className="px-6">
+					<Avatar className="w-16 h-16 object-cover rounded-full">
+						<AvatarImage src={image || ""} alt={displayName} />
+						<AvatarFallback className="rounded-full">
+							{username ? username[0].toUpperCase() : "U"}
+						</AvatarFallback>
+					</Avatar>
+					<DrawerTitle className="line-clamp-1 leading-relaxed">
+						{displayName}
+					</DrawerTitle>
+					<DrawerDescription className="line-clamp-1 leading-relaxed">
+						{authData.user.email}
+					</DrawerDescription>
+				</DrawerHeader>
+				<Separator />
+				<div className="no-scrollbar overflow-y-auto flex flex-col items-center my-4 gap-4 flex-1 px-3">
+					<Button
+						className="w-full justify-start"
+						variant="ghost"
+						onClick={() => {
+							setIsOpen(false);
+							navigate({
+								to: "/user/$username",
+								params: { username },
+							});
+						}}
+					>
+						<IconUser />
+						{m.dropdown_profile_text()}
+					</Button>
+					<Button
+						className="w-full justify-start"
+						variant="ghost"
+						onClick={() => {
+							setIsOpen(false);
+							navigate({
+								to: "/user/$username/watchlist",
+								params: { username },
+							});
+						}}
+					>
+						<IconClockBolt />
+						{m.dropdown_watchlist_text()}
+					</Button>
+					<Button
+						className="w-full justify-start"
+						variant="ghost"
+						onClick={() => {
+							setIsOpen(false);
+							navigate({
+								to: "/user/$username/lists",
+								params: { username },
+							});
+						}}
+					>
+						<IconList />
+						{m.dropdown_lists_text()}
+					</Button>
+					<Button
+						className="w-full justify-start"
+						variant="ghost"
+						onClick={() => {
+							setIsOpen(false);
+							navigate({
+								to: "/user/$username/favorites",
+								params: { username },
+							});
+						}}
+					>
+						<IconHeart />
+						{m.dropdown_favorites_text()}
+					</Button>
+					<Button
+						className="w-full justify-start"
+						variant="ghost"
+						onClick={() => {
+							setIsOpen(false);
+							navigate({
+								to: "/user/$username/history",
+								params: { username },
+							});
+						}}
+					>
+						<IconHistory />
+						{m.dropdown_history_text()}
+					</Button>
+					<Button
+						className="w-full justify-start"
+						variant="ghost"
+						onClick={() => {
+							setIsOpen(false);
+							navigate({
+								to: "/settings",
+							});
+						}}
+					>
+						<IconAdjustmentsHorizontal />
+						{m.dropdown_settings_text()}
+					</Button>
+					<Button className="w-full" variant="ghost">
+						<a
+							href="https://github.com/tristan-derez/bingy"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="flex items-center justify-between w-full"
+						>
+							<div className="flex items-center gap-2">
+								<IconBrandGithub className="w-4 h-4" />
+								<span>GitHub</span>
+							</div>
+							<IconExternalLink className="w-4 h-4 text-muted-foreground" />
+						</a>
+					</Button>
+					<Button disabled className="w-full justify-start" variant="ghost">
+						<IconLifebuoy className="w-4 h-4" />
+						<span>{m.dropdown_support_text()}</span>
+					</Button>
+				</div>
+				<Separator />
+				<DrawerFooter>
+					<Button onClick={logout} variant="destructive" className="w-full">
+						<IconLogout className="w-4 h-4" />
+						<span>{m.dropdown_logout_text()}</span>
+					</Button>
+				</DrawerFooter>
+			</DrawerContent>
+		</Drawer>
+	);
+}

--- a/apps/frontend/src/components/profile-drawer.tsx
+++ b/apps/frontend/src/components/profile-drawer.tsx
@@ -73,7 +73,16 @@ export function ProfileDrawer() {
 			/>
 			<DrawerContent className="focus:outline-none focus-visible:outline-none *:focus:outline-none">
 				<DrawerHeader className="px-6">
-					<Avatar className="w-16 h-16 object-cover rounded-full">
+					<Avatar
+						className="w-16 h-16 object-cover rounded-full cursor-pointer"
+						onClick={() => {
+							setIsOpen(false);
+							navigate({
+								to: "/user/$username",
+								params: { username },
+							});
+						}}
+					>
 						<AvatarImage src={image || ""} alt={displayName} />
 						<AvatarFallback className="rounded-full">
 							{username ? username[0].toUpperCase() : "U"}

--- a/apps/frontend/src/components/profile-dropdown.tsx
+++ b/apps/frontend/src/components/profile-dropdown.tsx
@@ -17,7 +17,6 @@ import {
 } from "@tanstack/react-router";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -31,6 +30,7 @@ import { authClient } from "@/lib/auth-client";
 import { sessionQueryOptions } from "@/lib/queries/session";
 import { cn } from "@/lib/utils";
 import { m } from "@/paraglide/messages";
+import { ProfileTriggerButton } from "./profile-trigger-button";
 
 interface ProfileDropdownProps extends React.HTMLAttributes<HTMLDivElement> {}
 
@@ -45,6 +45,8 @@ export const ProfileDropdown = ({
 
 	if (!authData) return null;
 	const username = authData.user.name;
+	const displayName = authData.user.displayName;
+	const image = authData.user.image;
 
 	const logout = async () => {
 		await authClient.signOut();
@@ -63,33 +65,11 @@ export const ProfileDropdown = ({
 				<div className="group relative">
 					<DropdownMenuTrigger
 						render={
-							<button
-								className={cn(
-									"flex items-center h-10 gap-2 p-3 rounded-md border transition-all duration-200 focus:outline-none",
-									"bg-transparent border-border hover:bg-card-foreground/10 hover:border-ring",
-								)}
-							>
-								<div className="text-left flex-1">
-									<div className="text-sm font-medium tracking-tight leading-tight text-foreground">
-										{authData.user.displayName}
-									</div>
-								</div>
-								<div className="relative">
-									<div className="w-8 h-8 rounded-full p-0.5">
-										<div className="w-full h-full rounded-full overflow-hidden bg-card">
-											<Avatar className="w-full h-full object-cover rounded-full">
-												<AvatarImage
-													src={authData.user?.image || ""}
-													alt={username}
-												/>
-												<AvatarFallback className="rounded-lg">
-													{username ? username[0].toUpperCase() : "U"}
-												</AvatarFallback>
-											</Avatar>
-										</div>
-									</div>
-								</div>
-							</button>
+							<ProfileTriggerButton
+								username={username}
+								displayName={displayName}
+								image={image}
+							/>
 						}
 					/>
 

--- a/apps/frontend/src/components/profile-trigger-button.tsx
+++ b/apps/frontend/src/components/profile-trigger-button.tsx
@@ -1,0 +1,51 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+
+interface ProfileTriggerButtonProps extends ComponentPropsWithoutRef<"button"> {
+	username: string;
+	displayName: string;
+	image?: string | null;
+	showUsername?: boolean;
+}
+
+export function ProfileTriggerButton({
+	username,
+	displayName,
+	image,
+	showUsername = true,
+	className,
+	...props
+}: ProfileTriggerButtonProps) {
+	return (
+		<button
+			{...props}
+			className={cn(
+				"flex items-center h-10 gap-2 p-3 rounded-md border transition-all duration-200 focus:outline-none",
+				"bg-transparent border-border hover:bg-card-foreground/10 hover:border-ring",
+				"focus:outline-none focus-visible:outline-none *:focus:outline-none",
+				className,
+			)}
+		>
+			{showUsername && (
+				<div className="text-left flex-1">
+					<div className="text-sm font-medium tracking-tight leading-tight text-foreground">
+						{displayName}
+					</div>
+				</div>
+			)}
+			<div className="relative">
+				<div className="w-8 h-8 rounded-full p-0.5">
+					<div className="w-full h-full rounded-full overflow-hidden bg-card">
+						<Avatar className="w-full h-full object-cover rounded-full">
+							<AvatarImage src={image || ""} alt={displayName} />
+							<AvatarFallback className="rounded-lg">
+								{username ? username[0].toUpperCase() : "U"}
+							</AvatarFallback>
+						</Avatar>
+					</div>
+				</div>
+			</div>
+		</button>
+	);
+}

--- a/apps/frontend/src/components/root-component.tsx
+++ b/apps/frontend/src/components/root-component.tsx
@@ -18,7 +18,7 @@ export function RootComponent() {
 		<div>
 			<HeadContent />
 			<Header />
-			<div className="pt-20 min-h-svh flex flex-col items-center py-22 lg:py-32 px-2 md:px-6 lg:px-12 2xl:px-32">
+			<div className="pt-20 min-h-svh flex flex-col items-center py-22 lg:py-32 px-5 md:px-6 lg:px-12 2xl:px-32">
 				<Outlet />
 				<GlobalLoadingIndicator />
 			</div>

--- a/apps/frontend/src/components/search/search-command-item.tsx
+++ b/apps/frontend/src/components/search/search-command-item.tsx
@@ -49,7 +49,9 @@ export const SearchCommandItem = ({
 							})}
 						</span>
 					)}
-					<MovieBadge />
+					<div className="hidden md:flex">
+						<MovieBadge />
+					</div>
 				</div>
 			</CommandItem>
 		);
@@ -82,7 +84,9 @@ export const SearchCommandItem = ({
 							})}
 						</span>
 					)}
-					<TvShowBadge />
+					<div className="hidden md:flex">
+						<TvShowBadge />
+					</div>
 				</div>
 			</CommandItem>
 		);
@@ -111,8 +115,9 @@ export const SearchCommandItem = ({
 							{item.known_for_department}
 						</span>
 					)}
-
-					<PersonBadge />
+					<div className="hidden md:flex">
+						<PersonBadge />
+					</div>
 				</div>
 			</CommandItem>
 		);

--- a/apps/frontend/src/components/theme/theme-toggle.tsx
+++ b/apps/frontend/src/components/theme/theme-toggle.tsx
@@ -24,11 +24,12 @@ export function ModeToggle() {
 	};
 
 	return (
-		<div ref={containerRef} className="flex space-x-2 w-full">
+		<div ref={containerRef} className="flex flex-col md:flex-row gap-2 w-full">
 			<Button
 				variant={theme === "light" ? "default" : "outline"}
 				onClick={() => handleThemeChange("light")}
-				className={`flex items-center gap-2 w-28 ${theme === "light" ? "hover:cursor-not-allowed" : ""}`}
+				disabled={theme === "light"}
+				className="flex items-center justify-start md:justify-center gap-2 w-full md:flex-1"
 			>
 				<IconSun />
 				{m.btn_light_mode()}
@@ -37,7 +38,8 @@ export function ModeToggle() {
 			<Button
 				variant={theme === "dark" ? "default" : "outline"}
 				onClick={() => handleThemeChange("dark")}
-				className={`flex items-center gap-2 w-28 ${theme === "dark" ? "hover:cursor-not-allowed" : ""}`}
+				disabled={theme === "dark"}
+				className="flex items-center justify-start md:justify-center gap-2 w-full md:flex-1"
 			>
 				<IconMoon />
 				{m.btn_dark_mode()}
@@ -46,7 +48,8 @@ export function ModeToggle() {
 			<Button
 				variant={theme === "system" ? "default" : "outline"}
 				onClick={() => handleThemeChange("system")}
-				className={`flex items-center gap-2 w-28 ${theme === "system" ? "hover:cursor-not-allowed" : ""}`}
+				disabled={theme === "system"}
+				className="flex items-center justify-start md:justify-center gap-2 w-full md:flex-1"
 			>
 				<IconBrandWindowsFilled />
 				{m.btn_system_mode()}

--- a/apps/frontend/src/components/tv/tv-details.tsx
+++ b/apps/frontend/src/components/tv/tv-details.tsx
@@ -69,7 +69,7 @@ export function TvDetailsView({
 	return (
 		<>
 			<MediaBackgroundImage backgroundImage={backgroundImage} />
-			<div className="container pt-10 lg:pt-30">
+			<div className="container pt-3 md:pt-10 lg:pt-30">
 				<BackButton />
 
 				<div className="grid lg:grid-cols-[auto_1fr] gap-2 lg:gap-4 pt-2 justify-items-center">
@@ -94,12 +94,12 @@ export function TvDetailsView({
 								<div className="flex flex-col md:flex-row md:justify-between md:items-start gap-2 px-0.5 py-0.5">
 									<div className="flex flex-col gap-4">
 										<div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-											<h1 className="text-4xl font-bold leading-relaxed">
+											<h1 className="text-2xl lg:text-4xl font-bold leading-relaxed">
 												{tv.name}
 											</h1>
 
 											{hasDifferentName ? (
-												<p className="text-foreground text-lg font-bold italic">
+												<p className="text-foreground text-base lg:text-xl font-bold italic">
 													— {tv.original_name}
 												</p>
 											) : null}
@@ -109,7 +109,9 @@ export function TvDetailsView({
 
 										<div className="flex flex-col gap-1">
 											{tv.tagline ? (
-												<p className="font-bold italic">{tv.tagline}</p>
+												<p className="font-bold italic text-base lg:text-lg">
+													{tv.tagline}
+												</p>
 											) : null}
 											<MediaOverview overview={tv.overview} />
 										</div>
@@ -122,7 +124,7 @@ export function TvDetailsView({
 															to="/person/$personId"
 															params={{ personId: creator.id.toString() }}
 														>
-															<h3 className="font-semibold text-lg whitespace-nowrap">
+															<h3 className="font-semibold text-base lg:text-lg whitespace-nowrap">
 																{creator.name}
 															</h3>
 														</Link>

--- a/apps/frontend/src/components/ui/drawer.tsx
+++ b/apps/frontend/src/components/ui/drawer.tsx
@@ -1,0 +1,129 @@
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content fixed z-50 flex h-auto flex-col bg-background text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-4 hidden h-1 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-0.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/apps/frontend/src/components/ui/drawer.tsx
+++ b/apps/frontend/src/components/ui/drawer.tsx
@@ -1,129 +1,152 @@
-import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Drawer({
-  ...props
+	...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+	return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
 }
 
 function DrawerTrigger({
-  ...props
+	...props
 }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
-  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+	return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
 function DrawerPortal({
-  ...props
+	...props
 }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
-  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+	return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
 function DrawerClose({
-  ...props
+	...props
 }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
-  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+	return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
-function DrawerOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
-  return (
-    <DrawerPrimitive.Overlay
-      data-slot="drawer-overlay"
-      className={cn(
-        "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
-      )}
-      {...props}
-    />
-  )
+function DrawerBackdrop({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Backdrop>) {
+	return (
+		<DrawerPrimitive.Backdrop
+			data-slot="drawer-backdrop"
+			className={cn(
+				"fixed inset-0 z-[60] bg-black/20 backdrop-blur-sm transition-opacity duration-300 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DrawerViewport({
+	className,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Viewport>) {
+	return (
+		<DrawerPrimitive.Viewport
+			data-slot="drawer-viewport"
+			className={cn("fixed inset-0 z-[70] flex items-stretch", className)}
+			{...props}
+		/>
+	);
 }
 
 function DrawerContent({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
-  return (
-    <DrawerPortal data-slot="drawer-portal">
-      <DrawerOverlay />
-      <DrawerPrimitive.Content
-        data-slot="drawer-content"
-        className={cn(
-          "group/drawer-content fixed z-50 flex h-auto flex-col bg-background text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          className
-        )}
-        {...props}
-      >
-        <div className="mx-auto mt-4 hidden h-1 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
-        {children}
-      </DrawerPrimitive.Content>
-    </DrawerPortal>
-  )
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof DrawerPrimitive.Popup>) {
+	return (
+		<DrawerPortal data-slot="drawer-portal">
+			<DrawerBackdrop />
+			<DrawerViewport>
+				<DrawerPrimitive.Popup
+					data-slot="drawer-content"
+					className={cn(
+						"group/drawer-content fixed z-50 flex h-auto flex-col bg-background text-sm transition-transform duration-450 ease-[cubic-bezier(0.32,0.72,0,1)]",
+						"data-[swipe-direction=down]:inset-x-0 data-[swipe-direction=down]:bottom-0 data-[swipe-direction=down]:mt-24 data-[swipe-direction=down]:max-h-[80vh] data-[swipe-direction=down]:rounded-t-xl data-[swipe-direction=down]:border-t",
+						"data-[swipe-direction=left]:inset-y-0 data-[swipe-direction=left]:left-0 data-[swipe-direction=left]:w-3/4 data-[swipe-direction=left]:rounded-r-xl data-[swipe-direction=left]:border-r data-[swipe-direction=left]:[transform:translateX(var(--drawer-swipe-movement-x))]",
+						"data-[swipe-direction=right]:inset-y-0 data-[swipe-direction=right]:right-0 data-[swipe-direction=right]:w-3/4 data-[swipe-direction=right]:rounded-l-xl data-[swipe-direction=right]:border-l data-[swipe-direction=right]:[transform:translateX(var(--drawer-swipe-movement-x))]",
+						"data-[swipe-direction=up]:inset-x-0 data-[swipe-direction=up]:top-0 data-[swipe-direction=up]:mb-24 data-[swipe-direction=up]:max-h-[80vh] data-[swipe-direction=up]:rounded-b-xl data-[swipe-direction=up]:border-b",
+						"data-[swipe-direction=left]:sm:max-w-sm data-[swipe-direction=right]:sm:max-w-sm",
+						"data-[starting-style]:data-[swipe-direction=left]:-translate-x-full data-[ending-style]:data-[swipe-direction=left]:-translate-x-full",
+						"data-[starting-style]:data-[swipe-direction=right]:translate-x-full data-[ending-style]:data-[swipe-direction=right]:translate-x-full",
+						className,
+					)}
+					{...props}
+				>
+					<div className="mx-auto mt-4 hidden h-1 w-[100px] shrink-0 rounded-full bg-muted group-data-[swipe-direction=down]/drawer-content:block" />
+					{children}
+				</DrawerPrimitive.Popup>
+			</DrawerViewport>
+		</DrawerPortal>
+	);
 }
 
 function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="drawer-header"
-      className={cn(
-        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-0.5 md:text-left",
-        className
-      )}
-      {...props}
-    />
-  )
+	return (
+		<div
+			data-slot="drawer-header"
+			className={cn(
+				"flex flex-col gap-0.5 p-4 group-data-[swipe-direction=down]/drawer-content:text-center group-data-[swipe-direction=up]/drawer-content:text-center md:gap-0.5 md:text-left",
+				className,
+			)}
+			{...props}
+		/>
+	);
 }
 
 function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="drawer-footer"
-      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
-      {...props}
-    />
-  )
+	return (
+		<div
+			data-slot="drawer-footer"
+			className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+			{...props}
+		/>
+	);
 }
 
 function DrawerTitle({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
-  return (
-    <DrawerPrimitive.Title
-      data-slot="drawer-title"
-      className={cn("text-base font-medium text-foreground", className)}
-      {...props}
-    />
-  )
+	return (
+		<DrawerPrimitive.Title
+			data-slot="drawer-title"
+			className={cn("text-base font-medium text-foreground", className)}
+			{...props}
+		/>
+	);
 }
 
 function DrawerDescription({
-  className,
-  ...props
+	className,
+	...props
 }: React.ComponentProps<typeof DrawerPrimitive.Description>) {
-  return (
-    <DrawerPrimitive.Description
-      data-slot="drawer-description"
-      className={cn("text-sm text-muted-foreground", className)}
-      {...props}
-    />
-  )
+	return (
+		<DrawerPrimitive.Description
+			data-slot="drawer-description"
+			className={cn("text-sm text-muted-foreground", className)}
+			{...props}
+		/>
+	);
 }
 
 export {
-  Drawer,
-  DrawerPortal,
-  DrawerOverlay,
-  DrawerTrigger,
-  DrawerClose,
-  DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
-  DrawerDescription,
-}
+	Drawer,
+	DrawerPortal,
+	DrawerBackdrop,
+	DrawerViewport,
+	DrawerTrigger,
+	DrawerClose,
+	DrawerContent,
+	DrawerHeader,
+	DrawerFooter,
+	DrawerTitle,
+	DrawerDescription,
+};

--- a/apps/frontend/src/components/ui/mobile-navbar.tsx
+++ b/apps/frontend/src/components/ui/mobile-navbar.tsx
@@ -70,14 +70,16 @@ export const MobileBottomNav = ({ items, className }: BottomNavProps) => {
 };
 
 interface MobileTopBarProps {
-	logo: React.ReactNode;
-	dropdown: React.ReactNode;
+	left: React.ReactNode;
+	center: React.ReactNode;
+	right: React.ReactNode;
 	className?: string;
 }
 
 export const MobileTopBar = ({
-	logo,
-	dropdown,
+	left,
+	center,
+	right,
 	className,
 }: MobileTopBarProps) => {
 	return (
@@ -89,8 +91,9 @@ export const MobileTopBar = ({
 			)}
 		>
 			<div className="flex items-center justify-between rounded-md border border-border bg-card/50 backdrop-blur-lg px-4 py-2 shadow-sm">
-				{logo}
-				{dropdown}
+				<div className="flex-1">{left}</div>
+				<div className="flex-shrink-0">{center}</div>
+				<div className="flex-1 flex justify-end">{right}</div>
 			</div>
 		</div>
 	);

--- a/apps/frontend/src/components/watch-providers/watch-providers-section.tsx
+++ b/apps/frontend/src/components/watch-providers/watch-providers-section.tsx
@@ -32,35 +32,42 @@ export function WatchProvidersSection({
 				</div>
 			) : null}
 			<div className="flex flex-row justify-center">
-				{displayedProviders.map((provider) => (
-					<a
-						key={provider.provider_id}
-						href={providers.link}
-						target="_blank"
-						rel="noopener noreferrer"
-						className="flex items-center gap-2 hover:opacity-80 transition-opacity pb-3 text-dark-card-foreground"
-					>
-						{provider.logo_path && (
-							<img
-								src={
-									provider.logo_path
-										? `https://image.tmdb.org/t/p/original${provider.logo_path}`
-										: undefined
-								}
-								alt={provider.provider_name}
-								className="w-10 h-10 rounded"
-							/>
-						)}
-						<div className="flex flex-col h-10 justify-center">
-							<span className="text-sm leading-relaxed">
-								{m.watch_providers_text()}
-							</span>
-							<span className="text-sm font-bold leading-relaxed">
-								{provider.provider_name}
-							</span>
-						</div>
-					</a>
-				))}
+				{displayedProviders.map((provider) => {
+					const providerName =
+						provider.provider_name === "Amazon Prime Video"
+							? "Prime Video"
+							: provider.provider_name;
+
+					return (
+						<a
+							key={provider.provider_id}
+							href={providers.link}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="flex items-center gap-2 hover:opacity-80 transition-opacity pb-3 text-dark-card-foreground"
+						>
+							{provider.logo_path && (
+								<img
+									src={
+										provider.logo_path
+											? `https://image.tmdb.org/t/p/original${provider.logo_path}`
+											: undefined
+									}
+									alt={providerName}
+									className="w-10 h-10 rounded"
+								/>
+							)}
+							<div className="flex flex-col h-10 justify-center">
+								<span className="text-sm leading-relaxed">
+									{m.watch_providers_text()}
+								</span>
+								<span className="text-base font-bold leading-relaxed">
+									{providerName}
+								</span>
+							</div>
+						</a>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/apps/frontend/src/integrations/media-query.tsx
+++ b/apps/frontend/src/integrations/media-query.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+	const [matches, setMatches] = useState(false);
+
+	useEffect(() => {
+		const media = window.matchMedia(query);
+
+		if (media.matches !== matches) {
+			setMatches(media.matches);
+		}
+
+		const listener = (event: MediaQueryListEvent) => {
+			setMatches(event.matches);
+		};
+
+		media.addEventListener("change", listener);
+
+		return () => media.removeEventListener("change", listener);
+	}, [matches, query]);
+
+	return matches;
+}

--- a/apps/frontend/src/routes/movies/index.tsx
+++ b/apps/frontend/src/routes/movies/index.tsx
@@ -58,7 +58,7 @@ function MoviesPage() {
 	});
 
 	return (
-		<div className="flex flex-col w-full p-4 gap-4">
+		<div className="flex flex-col w-full gap-4">
 			<NowPlayingMovies
 				title={m.movies_now_playing_title()}
 				movies={nowPlayingMovies}

--- a/apps/frontend/src/routes/tv/index.tsx
+++ b/apps/frontend/src/routes/tv/index.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/tv/")({
 
 function TvIndexPage() {
 	return (
-		<div className="flex flex-col w-full p-4 gap-4">
+		<div className="flex flex-col w-full gap-4">
 			<TopRatedTv title={m.tv_series_top_rated_title()} />
 			<TrendingTodayTv title={m.tv_series_trending_today_title()} />
 			<PopularTv title={m.tv_series_popular_title()} />

--- a/apps/frontend/src/styles/app.css
+++ b/apps/frontend/src/styles/app.css
@@ -143,8 +143,16 @@
 	* {
 		@apply border-border outline-ring/50;
 	}
+	html {
+		overscroll-behavior-x: none;
+		-webkit-overflow-scrolling: touch;
+		touch-action: pan-x pan-y;
+		height: 100%;
+	}
 	body {
 		@apply bg-background text-foreground;
+		overscroll-behavior-x: none;
+		overscroll-behavior-y: auto;
 	}
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,7 @@
     "apps/frontend": {
       "name": "frontend",
       "dependencies": {
-        "@base-ui/react": "^1.1.0",
+        "@base-ui/react": "^1.3.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -182,9 +182,9 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
-    "@base-ui/react": ["@base-ui/react@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@base-ui/utils": "0.2.4", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-ikcJRNj1mOiF2HZ5jQHrXoVoHcNHdBU5ejJljcBl+VTLoYXR6FidjTN86GjO6hyshi6TZFuNvv0dEOgaOFv6Lw=="],
+    "@base-ui/react": ["@base-ui/react@1.3.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.6", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA=="],
 
-    "@base-ui/utils": ["@base-ui/utils@0.2.4", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-smZwpMhjO29v+jrZusBSc5T+IJ3vBb9cjIiBjtKcvWmRj9Z4DWGVR3efr1eHR56/bqY5a4qyY9ElkOY5ljo3ng=="],
+    "@base-ui/utils": ["@base-ui/utils@0.2.6", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw=="],
 
     "@better-auth/core": ["@better-auth/core@1.4.9", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "zod": "^4.1.12" }, "peerDependencies": { "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.21", "better-call": "1.1.7", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" } }, "sha512-JT2q4NDkQzN22KclUEoZ7qU6tl9HUTfK1ctg2oWlT87SEagkwJcnrUwS9VznL+u9ziOIfY27P0f7/jSnmvLcoQ=="],
 
@@ -294,13 +294,13 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ=="],
 
-    "@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
-    "@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
 
-    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
-    "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.5", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-n4l4hutkfYU07PzRUHBOVzUEn38VSfrh+UVE5d0w4lyfWDOEhzxIupqo5iakRiJL44c3vTuFJBvcmUl8b9agIA=="],
 
@@ -1732,6 +1732,10 @@
 
     "@babel/template/@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
+    "@base-ui/react/@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
+    "@base-ui/utils/@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@img/sharp-linux-ppc64/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
@@ -1779,6 +1783,8 @@
     "@radix-ui/react-menu/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.0", "", { "dependencies": { "@radix-ui/react-slot": "1.2.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw=="],
 
     "@radix-ui/react-popover/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.0", "", { "dependencies": { "@radix-ui/react-slot": "1.2.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw=="],
+
+    "@radix-ui/react-popper/@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
 
     "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.0", "", { "dependencies": { "@radix-ui/react-slot": "1.2.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw=="],
 
@@ -2006,6 +2012,8 @@
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.4", "", { "dependencies": { "@floating-ui/core": "^1.7.3", "@floating-ui/utils": "^0.2.10" } }, "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA=="],
+
     "@react-email/preview-server/react-dom/scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
 
     "@react-email/preview-server/tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
@@ -2191,6 +2199,10 @@
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.1", "", { "os": "win32", "cpu": "x64" }, "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw=="],
 
     "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/core": ["@floating-ui/core@1.7.3", "", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
+
+    "@radix-ui/react-popper/@floating-ui/react-dom/@floating-ui/dom/@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
     "@react-email/preview-server/tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.13",
         "tw-animate-css": "^1.3.8",
+        "vaul": "^1.1.2",
         "zod": "^4.1.8",
       },
       "devDependencies": {
@@ -1648,6 +1649,8 @@
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 


### PR DESCRIPTION
add:
- drawer from base ui on device with with less than 768px instead of profile dropdown to navigate
<img width="389" height="847" alt="image" src="https://github.com/user-attachments/assets/7d0d019e-5394-4086-9a7c-4df3d4cc3ec8" />

while on desktop:
<img width="519" height="368" alt="image" src="https://github.com/user-attachments/assets/7bcef0d2-16ab-45e4-9b21-3e836101d538" />



- adjust padding/text size/layout on mobile
- localeDropdown is now a drawer on mobile

desktop:
<img width="400" height="329" alt="image" src="https://github.com/user-attachments/assets/fefc3ef8-e3af-47a7-b310-a42992c9d38e" />

mobile:
<img width="380" height="843" alt="image" src="https://github.com/user-attachments/assets/74caa38a-a38c-43a3-91e2-33dd3a37ca81" />
