### PR TITLE
fix: update biography width on mobile devices

### DIFF
--- a/apps/frontend/src/components/person/person-biography.tsx
+++ b/apps/frontend/src/components/person/person-biography.tsx
@@ -24,7 +24,9 @@ export const PersonBiography = ({ biography }: PersonBiographyProps) => {
 
 	if (!shouldTruncate) {
 		return (
-			<p className="whitespace-pre-line text-pretty w-6/7">{displayText}</p>
+			<p className="whitespace-pre-line text-pretty w-full lg:w-6/7">
+				{displayText}
+			</p>
 		);
 	}
 
@@ -34,7 +36,7 @@ export const PersonBiography = ({ biography }: PersonBiographyProps) => {
 			onOpenChange={setIsExpanded}
 			className="flex flex-col"
 		>
-			<div className="whitespace-pre-line text-pretty w-6/7">
+			<div className="whitespace-pre-line text-pretty w-full lg:w-6/7">
 				<span>{displayText}</span>
 				<CollapsibleContent
 					render={


### PR DESCRIPTION
- biography now takes full width on devices smaller than lg

before:

<img width="324" height="455" alt="image" src="https://github.com/user-attachments/assets/cd1a2f34-b576-4c9a-8998-81a93111cecf" />

after:

<img width="326" height="433" alt="image" src="https://github.com/user-attachments/assets/8d4c71ba-7e08-4c0c-901a-e1de129dc0eb" />

