### PR TITLE
refactor: create media poster container

### DIFF
--- a/apps/frontend/src/api/lists.ts
+++ b/apps/frontend/src/api/lists.ts
@@ -9,7 +9,7 @@ type WatchlistResponse = Pretty<{
 		releaseDate: string;
 		posterPath: string | null;
 		voteAverage: number;
-		mediaType: string;
+		mediaType: "movie" | "tv";
 		addedAt: Date;
 	}>;
 	page: number;

--- a/apps/frontend/src/components/lists/bottom-gradient.tsx
+++ b/apps/frontend/src/components/lists/bottom-gradient.tsx
@@ -1,0 +1,5 @@
+export function BottomGradient() {
+	return (
+		<div className="absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-black/90" />
+	);
+}

--- a/apps/frontend/src/components/lists/custom-lists/unranked-list/list-media-card.tsx
+++ b/apps/frontend/src/components/lists/custom-lists/unranked-list/list-media-card.tsx
@@ -1,10 +1,6 @@
 import { Link } from "@tanstack/react-router";
-import fallbackPoster from "@/assets/media-image-placeholder.jpg";
-import { MovieBadge } from "@/components/badges/movie-badge";
-import { TvShowBadge } from "@/components/badges/tv-badge";
 import { PositionBadge } from "@/components/lists/custom-lists/position-badge";
-import { ListDropdown } from "@/components/lists/media-actions/list-dropdown";
-import { getTmdbImageUrl } from "@/utils/utils";
+import { MediaPosterContainer } from "@/components/lists/media-poster-container";
 
 interface ListMediaCardProps {
 	item: {
@@ -22,65 +18,19 @@ interface ListMediaCardProps {
 }
 
 export const ListMediaCard = ({ item, showPosition }: ListMediaCardProps) => {
-	const imageUrl = getTmdbImageUrl(item.posterPath, "w500");
-
 	const linkTo =
 		item.mediaType === "movie" ? `/movies/${item.id}` : `/tv/${item.id}`;
-
-	const mediaProps =
-		item.mediaType === "movie"
-			? {
-					movie: {
-						mediaType: item.mediaType,
-						id: item.id,
-						title: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				}
-			: {
-					tvShow: {
-						mediaType: item.mediaType,
-						id: item.id,
-						name: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				};
 
 	return (
 		<div key={`${item.mediaType}-${item.id}`}>
 			<Link to={linkTo}>
-				<div className="relative aspect-2/3 overflow-hidden rounded-lg">
-					<img
-						src={imageUrl ?? fallbackPoster}
-						alt={item.title}
-						className="w-full h-full object-cover transition-transform"
-					/>
-					<div className="absolute inset-x-0 top-0 h-24 bg-linear-to-b from-black/90 to-transparent" />
-					<div className="absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-black/90" />
-
+				<MediaPosterContainer {...item}>
 					{showPosition && item.position ? (
 						<div className="absolute top-2 left-2 z-10">
 							<PositionBadge position={item.position} variant="overlay" />
 						</div>
 					) : null}
-
-					<div className="absolute top-2 right-2 z-10">
-						{item.mediaType === "movie" ? (
-							<MovieBadge minWidth={8} />
-						) : (
-							<TvShowBadge minWidth={8} />
-						)}
-					</div>
-
-					<div
-						className="absolute bottom-1.5 right-1.5 z-10"
-						onClick={(e) => e.stopPropagation()}
-					>
-						<ListDropdown {...mediaProps} imageUrl={imageUrl} />
-					</div>
-				</div>
+				</MediaPosterContainer>
 			</Link>
 		</div>
 	);

--- a/apps/frontend/src/components/lists/favorites/favorites-media-card.tsx
+++ b/apps/frontend/src/components/lists/favorites/favorites-media-card.tsx
@@ -1,10 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import fallbackPoster from "@/assets/media-image-placeholder.jpg";
-import { MovieBadge } from "@/components/badges/movie-badge";
-import { TvShowBadge } from "@/components/badges/tv-badge";
-import { ListDropdown } from "@/components/lists/media-actions/list-dropdown";
-import { formatEpisode } from "@/utils/format-season-episode";
-import { getTmdbImageUrl } from "@/utils/utils";
+import { MediaPosterContainer } from "@/components/lists/media-poster-container";
 
 interface FavoritesMediaCardProps {
 	item: {
@@ -30,65 +25,10 @@ export const FavoritesMediaCard = ({
 	item,
 	linkTo,
 }: FavoritesMediaCardProps) => {
-	const imageUrl = getTmdbImageUrl(item.posterPath, "w500");
-
-	const mediaProps =
-		item.mediaType === "movie"
-			? {
-					movie: {
-						mediaType: item.mediaType,
-						id: item.id,
-						title: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				}
-			: {
-					tvShow: {
-						mediaType: item.mediaType,
-						id: item.id,
-						name: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				};
-
 	return (
 		<div key={`${item.mediaType}-${item.id}`} className="group">
 			<Link to={linkTo}>
-				<div className="relative aspect-2/3 overflow-hidden rounded-lg">
-					<img
-						src={imageUrl ?? fallbackPoster}
-						alt={item.title}
-						className="w-full h-full object-cover transition-transform group-hover:scale-105"
-					/>
-					<div className="absolute inset-x-0 top-0 h-24 bg-linear-to-b from-black/90 to-transparent" />
-					<div className="absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-black/90" />
-					<div className="w-full absolute top-2 flex items-center justify-end z-10 pr-2">
-						{item.mediaType === "movie" ? (
-							<MovieBadge minWidth={8} />
-						) : (
-							<TvShowBadge minWidth={8} />
-						)}
-					</div>
-					<div className="absolute bottom-2 inset-x-0 flex items-center justify-between z-10 px-2">
-						{item.mediaType === "tv" && item.progress ? (
-							<div>
-								{formatEpisode(
-									item.progress.lastWatchedSeason,
-									item.progress.lastWatchedEpisode,
-									item.progress.absoluteEpisode,
-								)}
-							</div>
-						) : (
-							<span />
-						)}
-
-						<div onClick={(e) => e.stopPropagation()}>
-							<ListDropdown {...mediaProps} imageUrl={imageUrl} />
-						</div>
-					</div>
-				</div>
+				<MediaPosterContainer {...item} />
 			</Link>
 		</div>
 	);

--- a/apps/frontend/src/components/lists/history/history-media-card.tsx
+++ b/apps/frontend/src/components/lists/history/history-media-card.tsx
@@ -1,11 +1,7 @@
 import { IconStarFilled } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
-import fallbackPoster from "@/assets/media-image-placeholder.jpg";
-import { MovieBadge } from "@/components/badges/movie-badge";
-import { TvShowBadge } from "@/components/badges/tv-badge";
-import { ListDropdown } from "@/components/lists/media-actions/list-dropdown";
+import { MediaPosterContainer } from "@/components/lists/media-poster-container";
 import { formatEpisode } from "@/utils/format-season-episode";
-import { getTmdbImageUrl } from "@/utils/utils";
 
 interface HistoryMediaCardProps {
 	item: {
@@ -45,70 +41,28 @@ const RatingStars = ({ rating }: { rating: string }) => {
 };
 
 export const HistoryMediaCard = ({ item, linkTo }: HistoryMediaCardProps) => {
-	const imageUrl = getTmdbImageUrl(item.posterPath, "w500");
-
-	const mediaProps =
-		item.mediaType === "movie"
-			? {
-					movie: {
-						mediaType: item.mediaType,
-						id: item.id,
-						title: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				}
-			: {
-					tvShow: {
-						mediaType: item.mediaType,
-						id: item.id,
-						name: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				};
-
 	return (
 		<div key={`${item.mediaType}-${item.id}`} className="group">
 			<Link to={linkTo}>
-				<div className="relative aspect-2/3 overflow-hidden rounded-lg">
-					<img
-						src={imageUrl ?? fallbackPoster}
-						alt={item.title}
-						className="w-full h-full object-cover transition-transform group-hover:scale-105"
-					/>
-					<div className="absolute inset-x-0 top-0 h-24 bg-linear-to-b from-black/90 to-transparent" />
-					<div className="absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-black/90" />
-					<div className="w-full absolute top-2 flex items-center justify-end z-10 pr-2">
-						{item.mediaType === "movie" ? (
-							<MovieBadge minWidth={8} />
-						) : (
-							<TvShowBadge minWidth={8} />
-						)}
-					</div>
-					<div className="absolute bottom-2 inset-x-0 flex items-center justify-between z-10 px-2">
-						{item.mediaType === "tv" && item.progress ? (
-							<div>
-								{formatEpisode(
-									item.progress.lastWatchedSeason,
-									item.progress.lastWatchedEpisode,
-									item.progress.absoluteEpisode,
-								)}
-							</div>
-						) : (
-							<span />
-						)}
-
-						<div onClick={(e) => e.stopPropagation()}>
-							<ListDropdown {...mediaProps} imageUrl={imageUrl} />
+				<MediaPosterContainer {...item} />
+				<div className="flex flex-row justify-between items-center mt-2">
+					{item.mediaType === "tv" && item.progress ? (
+						<p className="text-sm text-muted-foreground">
+							{formatEpisode(
+								item.progress.lastWatchedSeason,
+								item.progress.lastWatchedEpisode,
+								item.progress.absoluteEpisode,
+							)}
+						</p>
+					) : (
+						<span />
+					)}
+					{item.rating ? (
+						<div>
+							<RatingStars rating={item.rating} />
 						</div>
-					</div>
+					) : null}
 				</div>
-				{item.rating ? (
-					<div className="mt-2">
-						<RatingStars rating={item.rating} />
-					</div>
-				) : null}
 			</Link>
 		</div>
 	);

--- a/apps/frontend/src/components/lists/media-poster-container.tsx
+++ b/apps/frontend/src/components/lists/media-poster-container.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { MovieBadge } from "@/components/badges/movie-badge";
+import { TvShowBadge } from "@/components/badges/tv-badge";
+import { BottomGradient } from "@/components/lists/bottom-gradient";
+import { ListDropdown } from "@/components/lists/media-actions/list-dropdown";
+import { TopGradient } from "@/components/lists/top-gradient";
+import { getMediaProps, getTmdbImageUrl } from "@/utils/utils";
+
+interface MediaPosterProps {
+	posterPath: string | null;
+	title: string;
+	mediaType: "movie" | "tv";
+	id: number;
+	releaseDate: string;
+	children?: ReactNode;
+}
+
+export function MediaPosterContainer({
+	posterPath,
+	title,
+	mediaType,
+	id,
+	releaseDate,
+	children,
+}: MediaPosterProps) {
+	const imageUrl = getTmdbImageUrl(posterPath, "w500");
+	const mediaProps = getMediaProps(
+		mediaType,
+		id,
+		title,
+		posterPath,
+		releaseDate,
+	);
+
+	return (
+		<div className="relative aspect-2/3 overflow-hidden rounded-lg">
+			<TopGradient />
+			<img
+				src={imageUrl ?? undefined}
+				alt={title}
+				className="w-full h-full object-cover transition-transform"
+			/>
+			<BottomGradient />
+			<div className="w-full absolute top-2 flex items-center justify-end z-10 pr-2">
+				{mediaType === "movie" ? (
+					<MovieBadge minWidth={8} />
+				) : (
+					<TvShowBadge minWidth={8} />
+				)}
+			</div>
+			<div
+				className="absolute bottom-1.5 right-1.5 z-10"
+				onClick={(e) => e.stopPropagation()}
+			>
+				<ListDropdown {...mediaProps} imageUrl={imageUrl} />
+			</div>
+			{children}
+		</div>
+	);
+}

--- a/apps/frontend/src/components/lists/top-gradient.tsx
+++ b/apps/frontend/src/components/lists/top-gradient.tsx
@@ -1,0 +1,5 @@
+export function TopGradient() {
+	return (
+		<div className="absolute inset-x-0 top-0 h-24 bg-linear-to-b from-black/90 to-transparent" />
+	);
+}

--- a/apps/frontend/src/components/lists/watchlist/watchlist-container.tsx
+++ b/apps/frontend/src/components/lists/watchlist/watchlist-container.tsx
@@ -16,7 +16,7 @@ type WatchlistContainerProps = {
 		releaseDate: string;
 		posterPath: string | null;
 		voteAverage: number;
-		mediaType: string;
+		mediaType: "movie" | "tv";
 		addedAt: Date;
 	}[];
 	filter: MediaFilter;

--- a/apps/frontend/src/components/lists/watchlist/watchlist-media-card.tsx
+++ b/apps/frontend/src/components/lists/watchlist/watchlist-media-card.tsx
@@ -1,9 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import fallbackPoster from "@/assets/media-image-placeholder.jpg";
-import { MovieBadge } from "@/components/badges/movie-badge";
-import { TvShowBadge } from "@/components/badges/tv-badge";
-import { getTmdbImageUrl } from "@/utils/utils";
-import { ListDropdown } from "../media-actions/list-dropdown";
+import { MediaPosterContainer } from "@/components/lists/media-poster-container";
 
 interface WatchlistMediaCardProps {
 	item: {
@@ -12,7 +8,7 @@ interface WatchlistMediaCardProps {
 		originalTitle: string;
 		releaseDate: string;
 		posterPath: string | null;
-		mediaType: string;
+		mediaType: "movie" | "tv";
 		addedAt: Date;
 	};
 	linkTo: string;
@@ -22,60 +18,10 @@ export const WatchlistMediaCard = ({
 	item,
 	linkTo,
 }: WatchlistMediaCardProps) => {
-	const imageUrl = getTmdbImageUrl(item.posterPath, "w500");
-
-	const mediaProps =
-		item.mediaType === "movie"
-			? {
-					movie: {
-						mediaType: item.mediaType,
-						id: item.id,
-						title: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				}
-			: {
-					tvShow: {
-						mediaType: item.mediaType,
-						id: item.id,
-						name: item.title,
-						posterPath: item.posterPath,
-						releaseDate: item.releaseDate,
-					},
-				};
-
 	return (
 		<div key={`${item.mediaType}-${item.id}`}>
 			<Link to={linkTo}>
-				<div className="relative aspect-2/3 overflow-hidden rounded-lg">
-					<img
-						src={imageUrl ?? fallbackPoster}
-						alt={item.title}
-						className="w-full h-full object-cover transition-transform"
-					/>
-					<div className="absolute inset-x-0 top-0 h-24 bg-linear-to-b from-black/90 to-transparent" />
-					<div className="absolute inset-x-0 bottom-0 h-12 bg-linear-to-b from-transparent to-black/90" />
-					<div className="w-full absolute top-2 flex items-center justify-end z-10 pr-2">
-						{item.mediaType === "movie" ? (
-							<MovieBadge minWidth={8} />
-						) : (
-							<TvShowBadge minWidth={8} />
-						)}
-					</div>
-					<div
-						className="absolute bottom-1.5 right-1.5 z-10"
-						onClick={(e) => e.stopPropagation()}
-					>
-						<ListDropdown {...mediaProps} imageUrl={imageUrl} />
-					</div>
-				</div>
-				<h3
-					className="mt-2 text-sm font-medium line-clamp-1 leading-relaxed hidden sm:block"
-					title={item.title}
-				>
-					{item.title}
-				</h3>
+				<MediaPosterContainer {...item} />
 			</Link>
 		</div>
 	);

--- a/apps/frontend/src/components/medias/carousel-card.tsx
+++ b/apps/frontend/src/components/medias/carousel-card.tsx
@@ -1,5 +1,3 @@
-import fallbackPoster from "@/assets/media-image-placeholder.jpg";
-
 interface CarouselCardProps {
 	imageUrl: string | null;
 	mediaName: string;
@@ -9,16 +7,10 @@ export function CarouselCard({ imageUrl, mediaName }: CarouselCardProps) {
 	return (
 		<div className="ring-foreground/10 ring-1 overflow-hidden flex flex-col select-none gap-2 shadow-none py-0 rounded-md w-30 h-45 md:w-45 md:h-67.5">
 			<img
-				src={imageUrl ?? fallbackPoster}
+				src={imageUrl ?? undefined}
 				alt={mediaName}
 				loading="lazy"
-				onError={(e) => {
-					const target = e.currentTarget;
-					if (target.src !== fallbackPoster) {
-						target.src = fallbackPoster;
-					}
-				}}
-				className="h-full w-full object-cover aspect-2/3"
+				className="h-full w-full object-cover aspect-2/3 ring-accent ring-1 flex items-center justify-center"
 			/>
 		</div>
 	);

--- a/apps/frontend/src/components/medias/media-portrait-image.tsx
+++ b/apps/frontend/src/components/medias/media-portrait-image.tsx
@@ -1,7 +1,5 @@
 import { useAtomValue } from "jotai";
-import type { SyntheticEvent } from "react";
 import type { Schemas } from "shared";
-import fallbackPoster from "@/assets/media-image-placeholder.jpg";
 import { WatchProvidersSection } from "@/components/watch-providers/watch-providers-section";
 import { regionAtom } from "@/lib/atoms/region";
 import { getTmdbImageUrl, type ImageSize } from "@/utils/utils";
@@ -22,20 +20,12 @@ export function MediaPortraitImage({
 	const region = useAtomValue(regionAtom);
 	const imageUrl = getTmdbImageUrl(imagePath, imageSize);
 
-	const handleImageError = (e: SyntheticEvent<HTMLImageElement>) => {
-		const target = e.currentTarget;
-		if (target.src !== fallbackPoster) {
-			target.src = fallbackPoster;
-		}
-	};
-
 	return (
 		<div className="relative">
 			<img
-				src={imageUrl ?? fallbackPoster}
+				src={imageUrl ?? undefined}
 				alt={alt}
-				className="aspect-2/3 w-44 h-65 md:w-52 md:h-80 lg:w-67 lg:h-100 xl:w-80 xl:h-120 rounded-lg shadow-lg"
-				onError={handleImageError}
+				className="aspect-2/3 w-44 h-65 md:w-52 md:h-80 lg:w-67 lg:h-100 xl:w-80 xl:h-120 rounded-lg shadow-lg flex items-center justify-center ring-accent ring-1"
 			/>
 
 			{watchProviders ? (

--- a/apps/frontend/src/components/person/person-profile-portrait-image.tsx
+++ b/apps/frontend/src/components/person/person-profile-portrait-image.tsx
@@ -1,5 +1,3 @@
-import type { SyntheticEvent } from "react";
-import fallbackPoster from "@/assets/user-placeholder.jpg";
 import { getTmdbImageUrl, type ImageSize } from "@/utils/utils";
 
 interface PersonProfilePortraitImageProps {
@@ -15,19 +13,11 @@ export function PersonProfilePortraitImage({
 }: PersonProfilePortraitImageProps) {
 	const imageUrl = getTmdbImageUrl(imagePath, imageSize);
 
-	const handleImageError = (e: SyntheticEvent<HTMLImageElement>) => {
-		const target = e.currentTarget;
-		if (target.src !== fallbackPoster) {
-			target.src = fallbackPoster;
-		}
-	};
-
 	return (
 		<img
-			src={imageUrl ?? fallbackPoster}
+			src={imageUrl ?? undefined}
 			alt={alt}
-			className="aspect-2/3 w-44 h-65 md:w-52 md:h-80 lg:w-67 lg:h-100 xl:w-80 xl:h-120 rounded-lg shadow-lg"
-			onError={handleImageError}
+			className="aspect-2/3 w-44 h-65 md:w-52 md:h-80 lg:w-67 lg:h-100 xl:w-80 xl:h-120 rounded-lg shadow-lg flex items-center justify-center ring-accent ring-1"
 		/>
 	);
 }

--- a/apps/frontend/src/utils/utils.ts
+++ b/apps/frontend/src/utils/utils.ts
@@ -27,3 +27,31 @@ export function isOwnProfile(
 export const isMacOS = () => {
 	return navigator.userAgent.indexOf("Mac") > -1;
 };
+
+export const getMediaProps = (
+	mediaType: "movie" | "tv",
+	id: number,
+	title: string,
+	posterPath: string | null,
+	releaseDate: string,
+) => {
+	return mediaType === "movie"
+		? {
+				movie: {
+					mediaType,
+					id,
+					title,
+					posterPath,
+					releaseDate,
+				},
+			}
+		: {
+				tvShow: {
+					mediaType,
+					id,
+					name: title,
+					posterPath,
+					releaseDate,
+				},
+			};
+};


### PR DESCRIPTION
- use the same layout for every card items in watchlist/favorites/lists/history
- create an helper for item props