### PR TITLE
fix: update season helper

### DIFF
--- a/apps/backend/src/web/routes/user-history.ts
+++ b/apps/backend/src/web/routes/user-history.ts
@@ -376,9 +376,19 @@ userHistoryRoutes.get(
 				rating: tvShowWatchHistory.rating,
 				review: tvShowWatchHistory.review,
 				watchedAt: tvShowWatchHistory.watchedAt,
+				seasonNumber: tvShowProgress.lastWatchedSeason,
+				episodeNumber: tvShowProgress.lastWatchedEpisode,
+				absoluteEpisode: tvShowProgress.absoluteEpisode,
 			})
 			.from(tvShowWatchHistory)
 			.innerJoin(media, eq(media.id, tvShowWatchHistory.mediaId))
+			.leftJoin(
+				tvShowProgress,
+				and(
+					eq(tvShowProgress.mediaId, media.id),
+					eq(tvShowProgress.userId, targetUser.id),
+				),
+			)
 			.where(
 				and(
 					eq(tvShowWatchHistory.userId, targetUser.id),
@@ -387,7 +397,7 @@ userHistoryRoutes.get(
 				),
 			);
 
-		return c.json(entry ?? null, 200);
+		return c.json(entry, 200);
 	},
 );
 

--- a/apps/frontend/src/api/rating.ts
+++ b/apps/frontend/src/api/rating.ts
@@ -15,14 +15,14 @@ export const getRatings = async (
 };
 
 export const getMovieRating = async (username: string, tmdbId: number) => {
-	const res = await apiFetch<GetRatingResponse>(
+	const res = await apiFetch<GetMovieRatingResponse>(
 		`/history/${username}/movie/${tmdbId}`,
 	);
 	return res;
 };
 
 export const getTvRating = async (username: string, tmdbId: number) => {
-	const res = await apiFetch<GetRatingResponse>(
+	const res = await apiFetch<GetTVRatingResponse>(
 		`/history/${username}/tv/${tmdbId}`,
 	);
 	return res;
@@ -101,12 +101,19 @@ export type GetRatingsResponse = Pretty<{
 	total_results: number;
 }>;
 
-export type GetRatingResponse = Pretty<{
+export type GetMovieRatingResponse = Pretty<{
 	rating: number | null;
 	review: string | null;
 	watchedAt: Date | null;
-	seasonNumber?: string | null;
-	episodeNumber?: string | null;
+}>;
+
+export type GetTVRatingResponse = Pretty<{
+	rating: number | null;
+	review: string | null;
+	watchedAt: Date | null;
+	seasonNumber: number | null;
+	episodeNumber: number | null;
+	absoluteEpisode: number | null;
 }>;
 
 type GetMediaAverageRatingResponse =

--- a/apps/frontend/src/components/lists/history/add-to-history-item.tsx
+++ b/apps/frontend/src/components/lists/history/add-to-history-item.tsx
@@ -1,11 +1,12 @@
 import { useAtomValue } from "jotai";
+import { useMemo } from "react";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { useAddMovieToHistory, useAddTvToHistory } from "@/hooks/useHistory";
 import { useMovieRating, useTvRating } from "@/hooks/useRating";
 import { useTv } from "@/hooks/useTv";
 import { localeRegionAtom } from "@/lib/atoms/region";
 import { m } from "@/paraglide/messages";
-import { getLastAiredEpisodeInfo } from "@/utils/season-helper";
+import { getTvShowProgress } from "@/utils/season-helper";
 
 interface AddToHistoryItemProps {
 	movie?: {
@@ -34,6 +35,8 @@ export function AddToHistoryItem({
 		{ enabled: !!tvShow?.id },
 	);
 
+	const tvProgress = useMemo(() => getTvShowProgress(tvDetails), [tvDetails]);
+
 	const movieRating = useMovieRating(username, movie?.id ?? 0);
 	const tvRating = useTvRating(username, tvShow?.id ?? 0);
 
@@ -52,14 +55,12 @@ export function AddToHistoryItem({
 				rating: null,
 				review: null,
 			});
-		} else if (tvShow) {
-			const episodeInfo = getLastAiredEpisodeInfo(tvDetails);
-			if (!episodeInfo) return;
-
+		} else if (tvShow && tvProgress?.lastAired) {
+			const { lastAired } = tvProgress;
 			addTvToHistory.mutate({
 				tmdbId: tvShow.id,
-				lastWatchedSeason: episodeInfo.seasonNumber ?? null,
-				lastWatchedEpisode: episodeInfo.episodeNumber ?? null,
+				lastWatchedSeason: lastAired.seasonNumber,
+				lastWatchedEpisode: lastAired.episodeNumber,
 				absoluteEpisode: null,
 				trackingMode: "season",
 				rating: null,

--- a/apps/frontend/src/components/lists/media-actions/absolute-episode-combobox.tsx
+++ b/apps/frontend/src/components/lists/media-actions/absolute-episode-combobox.tsx
@@ -12,8 +12,8 @@ import { m } from "@/paraglide/messages";
 
 interface AbsoluteEpisodeComboboxProps {
 	totalEpisodes: number;
-	selectedEpisode: string;
-	onEpisodeChange: (episode: string) => void;
+	selectedEpisode: number | null;
+	onEpisodeChange: (episode: number | null) => void;
 }
 
 export function AbsoluteEpisodeCombobox({
@@ -22,23 +22,11 @@ export function AbsoluteEpisodeCombobox({
 	onEpisodeChange,
 }: AbsoluteEpisodeComboboxProps) {
 	const episodes = useMemo(
-		() =>
-			Array.from({ length: totalEpisodes }, (_, i) => {
-				const num = (i + 1).toString();
-				return { value: num, label: num };
-			}),
+		() => Array.from({ length: totalEpisodes }, (_, i) => i + 1),
 		[totalEpisodes],
 	);
 
-	const [inputValue, setInputValue] = useState(selectedEpisode);
 	const [isOpen, setIsOpen] = useState(false);
-
-	const shouldShowClear = Boolean(selectedEpisode);
-
-	const filteredEpisodes = useMemo(() => {
-		if (!inputValue) return episodes;
-		return episodes.filter((ep) => ep.label.includes(inputValue));
-	}, [episodes, inputValue]);
 
 	return (
 		<div className="flex flex-col gap-2">
@@ -48,28 +36,25 @@ export function AbsoluteEpisodeCombobox({
 				onOpenChange={setIsOpen}
 				value={selectedEpisode}
 				onValueChange={(val) => {
-					onEpisodeChange(val ?? "");
-					if (val) setInputValue(val);
+					onEpisodeChange(val ?? null);
 				}}
-				inputValue={inputValue}
-				onInputValueChange={setInputValue}
 			>
 				<ComboboxInput
 					placeholder={m.log_review_dialog_absolute_episode_combobox_placeholder()}
-					showClear={shouldShowClear}
+					showClear={!!selectedEpisode}
 				/>
 
 				<ComboboxContent>
-					{filteredEpisodes.length === 0 ? (
+					{episodes.length === 0 ? (
 						<ComboboxEmpty>
 							{m.log_review_dialog_absolute_episode_combobox_no_result()}
 						</ComboboxEmpty>
 					) : null}
 
 					<ComboboxList>
-						{filteredEpisodes.map((episode) => (
-							<ComboboxItem key={episode.value} value={episode.value}>
-								{episode.label}
+						{episodes.map((episodeNum) => (
+							<ComboboxItem key={episodeNum} value={episodeNum.toString()}>
+								{episodeNum}
 							</ComboboxItem>
 						))}
 					</ComboboxList>

--- a/apps/frontend/src/components/lists/media-actions/list-dropdown.tsx
+++ b/apps/frontend/src/components/lists/media-actions/list-dropdown.tsx
@@ -1,6 +1,15 @@
 import { IconDots } from "@tabler/icons-react";
 import { useRouteContext } from "@tanstack/react-router";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { AddToHistoryItem } from "@/components/lists/history/add-to-history-item";
+import { RemoveFromHistoryItem } from "@/components/lists/history/remove-from-history-item";
+import { AddToListDialog } from "@/components/lists/media-actions/add-to-list-dialog";
+import { LogReviewDialog } from "@/components/lists/media-actions/log-review-dialog";
+import { RemoveHistoryAlertDialog } from "@/components/lists/media-actions/remove-history-alert-dialog";
+import { RemoveRatingDropdownItem } from "@/components/lists/media-actions/remove-rating-dropdown-item";
+import { StarRating } from "@/components/lists/media-actions/star-rating";
+import { AddToWatchlistItem } from "@/components/lists/watchlist/add-to-watchlist-item";
+import { RemoveFromWatchlistItem } from "@/components/lists/watchlist/remove-from-watchlist-item";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -17,16 +26,7 @@ import {
 } from "@/hooks/useRating";
 import { useTv } from "@/hooks/useTv";
 import { m } from "@/paraglide/messages";
-import { getLastAiredEpisodeInfo } from "@/utils/season-helper";
-import { AddToHistoryItem } from "../history/add-to-history-item";
-import { RemoveFromHistoryItem } from "../history/remove-from-history-item";
-import { AddToWatchlistItem } from "../watchlist/add-to-watchlist-item";
-import { RemoveFromWatchlistItem } from "../watchlist/remove-from-watchlist-item";
-import { AddToListDialog } from "./add-to-list-dialog";
-import { LogReviewDialog } from "./log-review-dialog";
-import { RemoveHistoryAlertDialog } from "./remove-history-alert-dialog";
-import { RemoveRatingDropdownItem } from "./remove-rating-dropdown-item";
-import { StarRating } from "./star-rating";
+import { getTvShowProgress } from "@/utils/season-helper";
 
 interface ListDropdownProps {
 	movie?: {
@@ -48,22 +48,17 @@ interface ListDropdownProps {
 
 export function ListDropdown({ movie, tvShow, imageUrl }: ListDropdownProps) {
 	const { authData } = useRouteContext({ from: "__root__" });
+	if (!authData) return null;
+	const username = authData.user.name;
 	const isTvShow = !!tvShow;
 	const tmdbId = isTvShow ? tvShow.id : (movie?.id ?? 0);
 
-	const { data: tvDetails } = useTv(
-		tmdbId,
-		{},
-		{
-			enabled: isTvShow,
-		},
-	);
+	const { data: tvDetails } = useTv(tmdbId, {}, { enabled: isTvShow });
 
-	const { data: movieRating } = useMovieRating(
-		authData?.user.name ?? "",
-		tmdbId,
-	);
-	const { data: tvRating } = useTvRating(authData?.user.name ?? "", tmdbId);
+	const tvProgress = useMemo(() => getTvShowProgress(tvDetails), [tvDetails]);
+
+	const { data: movieRating } = useMovieRating(username, tmdbId);
+	const { data: tvRating } = useTvRating(username, tmdbId);
 
 	const rateMovieMutation = useRateMovie();
 	const rateTvMutation = useRateTvShow();
@@ -76,7 +71,6 @@ export function ListDropdown({ movie, tvShow, imageUrl }: ListDropdownProps) {
 
 	if (!authData) return null;
 
-	const username = authData.user.name;
 	const existingRating = isTvShow ? tvRating : movieRating;
 
 	const handleRatingChange = (newRating: number) => {
@@ -89,15 +83,14 @@ export function ListDropdown({ movie, tvShow, imageUrl }: ListDropdownProps) {
 			});
 		}
 
-		const episodeInfo = getLastAiredEpisodeInfo(tvDetails);
-		if (!episodeInfo) return;
+		if (!tvProgress?.lastAired) return;
 
 		rateTvMutation.mutate({
 			tmdbId,
 			rating: newRating,
 			review: null,
-			lastWatchedSeason: episodeInfo.seasonNumber,
-			lastWatchedEpisode: episodeInfo.episodeNumber,
+			lastWatchedSeason: tvProgress.lastAired.seasonNumber,
+			lastWatchedEpisode: tvProgress.lastAired.episodeNumber,
 			absoluteEpisode: null,
 			trackingMode: "season",
 			watchedAt: new Date(),
@@ -141,19 +134,12 @@ export function ListDropdown({ movie, tvShow, imageUrl }: ListDropdownProps) {
 							? m.list_dropdown_editreview()
 							: m.list_dropdown_logreview()}
 					</DropdownMenuItem>
-					<DropdownMenuItem
-						onClick={() => {
-							setShowAddToListDialog(true);
-						}}
-					>
+					<DropdownMenuItem onClick={() => setShowAddToListDialog(true)}>
 						{m.list_dropdown_item_add_to_list()}
 					</DropdownMenuItem>
 					<AddToWatchlistItem movie={movie} tvShow={tvShow} />
 					<AddToHistoryItem movie={movie} tvShow={tvShow} username={username} />
 
-					{/* items below will only be shown if item is in their category
-						eg: if a tv show is in watchlist, remove from watchlist will be shown
-					*/}
 					<DropdownMenuSeparator />
 					<RemoveFromWatchlistItem movie={movie} tvShow={tvShow} />
 					<RemoveRatingDropdownItem

--- a/apps/frontend/src/components/lists/media-actions/log-review-dialog.tsx
+++ b/apps/frontend/src/components/lists/media-actions/log-review-dialog.tsx
@@ -19,7 +19,6 @@ import { useRateMovie, useRateTvShow } from "@/hooks/useRating";
 import { useTv } from "@/hooks/useTv";
 import { m } from "@/paraglide/messages";
 import { getTvShowProgress } from "@/utils/season-helper";
-import { getNumberOrNull } from "@/utils/utils";
 
 interface LogReviewDialogProps {
 	open: boolean;
@@ -42,7 +41,7 @@ interface LogReviewDialogProps {
 		watchedAt: Date | null;
 		seasonNumber?: number | null;
 		episodeNumber?: number | null;
-		absoluteEpisode?: number | null; // @todo: use correct number type here
+		absoluteEpisode?: number | null;
 	};
 }
 
@@ -51,7 +50,7 @@ interface ReviewFormData {
 	season: number | null;
 	episode: number | null;
 	shouldUseAbsoluteEpisode: boolean;
-	absoluteEpisode: string;
+	absoluteEpisode: number | null;
 	isComplete: boolean;
 	review: string;
 	watchedDate: Date;
@@ -62,7 +61,7 @@ const initialFormData = {
 	season: null,
 	episode: null,
 	shouldUseAbsoluteEpisode: false,
-	absoluteEpisode: "",
+	absoluteEpisode: null,
 	isComplete: false,
 	review: "",
 	hasSpecificDate: true,
@@ -111,20 +110,23 @@ export function LogReviewDialog({
 		onOpenChange(newOpen);
 	};
 
-	// Sync form with existing data
 	useEffect(() => {
 		if (!existingData || !open) return;
+
+		const hasAbsoluteEpisode = existingData.absoluteEpisode !== null;
 
 		setReviewFormData((prev) => ({
 			...prev,
 			rating,
 			review: existingData.review ?? "",
-			season: existingData.seasonNumber ?? 0,
-			episode: existingData.episodeNumber ?? 0,
+			shouldUseAbsoluteEpisode: hasAbsoluteEpisode,
+			absoluteEpisode: existingData.absoluteEpisode ?? null,
+			season: hasAbsoluteEpisode ? null : (existingData.seasonNumber ?? null),
+			episode: hasAbsoluteEpisode ? null : (existingData.episodeNumber ?? null),
 			watchedDate: existingData.watchedAt
 				? new Date(existingData.watchedAt)
 				: new Date(),
-			hasSpecificDate: !!existingData.watchedAt, // keep track of checkboxes states
+			hasSpecificDate: !!existingData.watchedAt,
 		}));
 	}, [open, existingData, rating]);
 
@@ -160,7 +162,7 @@ export function LogReviewDialog({
 			shouldUseAbsoluteEpisode: checked,
 			season: null,
 			episode: null,
-			absoluteEpisode: "",
+			absoluteEpisode: null,
 			isComplete: false,
 		}));
 	};
@@ -186,7 +188,7 @@ export function LogReviewDialog({
 				...payload,
 				lastWatchedSeason: reviewFormData.season,
 				lastWatchedEpisode: reviewFormData.episode,
-				absoluteEpisode: getNumberOrNull(reviewFormData.absoluteEpisode),
+				absoluteEpisode: reviewFormData.absoluteEpisode,
 				trackingMode: reviewFormData.shouldUseAbsoluteEpisode
 					? "absolute"
 					: "season",

--- a/apps/frontend/src/components/lists/media-actions/log-review-dialog.tsx
+++ b/apps/frontend/src/components/lists/media-actions/log-review-dialog.tsx
@@ -1,4 +1,9 @@
-import { type FormEvent, useEffect, useState } from "react";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
+import { AbsoluteEpisodeCombobox } from "@/components/lists/media-actions/absolute-episode-combobox";
+import { ReviewTextarea } from "@/components/lists/media-actions/review-text-area";
+import { SeasonEpisodeCombobox } from "@/components/lists/media-actions/season-episode-combobox";
+import { StarRating } from "@/components/lists/media-actions/star-rating";
+import { WatchedDateControl } from "@/components/lists/media-actions/watched-date-controls";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -13,17 +18,8 @@ import { Label } from "@/components/ui/label";
 import { useRateMovie, useRateTvShow } from "@/hooks/useRating";
 import { useTv } from "@/hooks/useTv";
 import { m } from "@/paraglide/messages";
-import {
-	getHasContinuousEpisodeNumbering,
-	getLastAiredEpisodeInfo,
-	getValidSeasons,
-} from "@/utils/season-helper";
+import { getTvShowProgress } from "@/utils/season-helper";
 import { getNumberOrNull } from "@/utils/utils";
-import { AbsoluteEpisodeCombobox } from "./absolute-episode-combobox";
-import { ReviewTextarea } from "./review-text-area";
-import { SeasonEpisodeCombobox } from "./season-episode-combobox";
-import { StarRating } from "./star-rating";
-import { WatchedDateControl } from "./watched-date-controls";
 
 interface LogReviewDialogProps {
 	open: boolean;
@@ -44,15 +40,16 @@ interface LogReviewDialogProps {
 		rating: number | null;
 		review: string | null;
 		watchedAt: Date | null;
-		seasonNumber?: string | null;
-		episodeNumber?: string | null;
+		seasonNumber?: number | null;
+		episodeNumber?: number | null;
+		absoluteEpisode?: number | null; // @todo: use correct number type here
 	};
 }
 
 interface ReviewFormData {
 	rating: number;
-	season: string;
-	episode: string;
+	season: number | null;
+	episode: number | null;
 	shouldUseAbsoluteEpisode: boolean;
 	absoluteEpisode: string;
 	isComplete: boolean;
@@ -62,8 +59,8 @@ interface ReviewFormData {
 }
 
 const initialFormData = {
-	season: "",
-	episode: "",
+	season: null,
+	episode: null,
 	shouldUseAbsoluteEpisode: false,
 	absoluteEpisode: "",
 	isComplete: false,
@@ -86,6 +83,14 @@ export function LogReviewDialog({
 
 	const { data: tvDetails } = useTv(tmdbId, {}, { enabled: isTvShow });
 
+	const tvProgress = useMemo(() => getTvShowProgress(tvDetails), [tvDetails]);
+
+	const validSeasons = tvProgress?.validSeasons ?? [];
+	const lastAired = tvProgress?.lastAired ?? null;
+	const hasContinuousNumbering = lastAired?.isContinuous ?? false;
+	const totalEpisodes = tvDetails?.number_of_episodes ?? 0;
+	const mediaTitle = isTvShow ? tvShow.name : movie?.title;
+
 	const rateMovieMutation = useRateMovie();
 	const rateTvMutation = useRateTvShow();
 
@@ -94,11 +99,6 @@ export function LogReviewDialog({
 		rating,
 		watchedDate: new Date(),
 	});
-
-	const seasons = getValidSeasons(tvDetails?.seasons);
-	const hasContinuousNumbering = getHasContinuousEpisodeNumbering(tvDetails);
-	const totalEpisodes = tvDetails?.number_of_episodes ?? 0;
-	const mediaTitle = isTvShow ? tvShow.name : movie?.title;
 
 	const handleOpenChange = (newOpen: boolean) => {
 		if (!newOpen) {
@@ -111,7 +111,7 @@ export function LogReviewDialog({
 		onOpenChange(newOpen);
 	};
 
-	// sync form with data available via the query
+	// Sync form with existing data
 	useEffect(() => {
 		if (!existingData || !open) return;
 
@@ -119,40 +119,38 @@ export function LogReviewDialog({
 			...prev,
 			rating,
 			review: existingData.review ?? "",
-			season: existingData.seasonNumber ?? "",
-			episode: existingData.episodeNumber ?? "",
+			season: existingData.seasonNumber ?? 0,
+			episode: existingData.episodeNumber ?? 0,
 			watchedDate: existingData.watchedAt
 				? new Date(existingData.watchedAt)
 				: new Date(),
 			hasSpecificDate: !!existingData.watchedAt, // keep track of checkboxes states
 		}));
-	}, [open, existingData]);
+	}, [open, existingData, rating]);
 
 	const handleHasSpecificDateChange = (checked: boolean) => {
-		setReviewFormData((prev) => ({
-			...prev,
-			hasSpecificDate: checked,
-		}));
+		setReviewFormData((prev) => ({ ...prev, hasSpecificDate: checked }));
 	};
 
-	const handleCompleteChange = (checked: boolean) => {
-		if (!checked) {
+	const handleCompleteChange = (checked: boolean | string) => {
+		const isChecked = checked === true;
+		if (!isChecked) {
 			return setReviewFormData((prev) => ({
 				...prev,
 				isComplete: false,
-				season: "",
-				episode: "",
+				season: null,
+				episode: null,
 			}));
 		}
 
-		const episodeInfo = getLastAiredEpisodeInfo(tvDetails);
-		if (!episodeInfo) return;
+		if (!lastAired) return;
 
+		// Uses the normalized numbers (e.g., S22 E66 instead of E1155)
 		setReviewFormData((prev) => ({
 			...prev,
 			isComplete: true,
-			season: episodeInfo.seasonNumber.toString(),
-			episode: episodeInfo.episodeNumber.toString(),
+			season: lastAired.seasonNumber,
+			episode: lastAired.episodeNumber,
 		}));
 	};
 
@@ -160,8 +158,8 @@ export function LogReviewDialog({
 		setReviewFormData((prev) => ({
 			...prev,
 			shouldUseAbsoluteEpisode: checked,
-			season: "",
-			episode: "",
+			season: null,
+			episode: null,
 			absoluteEpisode: "",
 			isComplete: false,
 		}));
@@ -186,8 +184,8 @@ export function LogReviewDialog({
 		rateTvMutation.mutate(
 			{
 				...payload,
-				lastWatchedSeason: getNumberOrNull(reviewFormData.season),
-				lastWatchedEpisode: getNumberOrNull(reviewFormData.episode),
+				lastWatchedSeason: reviewFormData.season,
+				lastWatchedEpisode: reviewFormData.episode,
 				absoluteEpisode: getNumberOrNull(reviewFormData.absoluteEpisode),
 				trackingMode: reviewFormData.shouldUseAbsoluteEpisode
 					? "absolute"
@@ -306,7 +304,8 @@ export function LogReviewDialog({
 													/>
 												) : (
 													<SeasonEpisodeCombobox
-														seasons={seasons}
+														lastAired={tvProgress?.lastAired}
+														seasons={validSeasons}
 														selectedSeason={reviewFormData.season}
 														selectedEpisode={reviewFormData.episode}
 														onSeasonChange={(season) =>

--- a/apps/frontend/src/components/lists/media-actions/media-action-menu.tsx
+++ b/apps/frontend/src/components/lists/media-actions/media-action-menu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -9,7 +9,7 @@ import {
 } from "@/hooks/useRating";
 import { useTv } from "@/hooks/useTv";
 import { m } from "@/paraglide/messages";
-import { getLastAiredEpisodeInfo } from "@/utils/season-helper";
+import { getTvShowProgress } from "@/utils/season-helper";
 import { getTmdbImageUrl } from "@/utils/utils";
 import { WatchlistToggleButton } from "../watchlist/watchlist-toggle-button";
 import { AddToListButton } from "./action-bar/add-to-list-button";
@@ -54,13 +54,9 @@ export const MediaActionMenu = ({
 	const isTvShow = !!tvShow;
 	const tmdbId = isTvShow ? tvShow.id : (movie?.id ?? 0);
 
-	const { data: tvDetails } = useTv(
-		tmdbId,
-		{},
-		{
-			enabled: isTvShow,
-		},
-	);
+	const { data: tvDetails } = useTv(tmdbId, {}, { enabled: isTvShow });
+
+	const tvProgress = useMemo(() => getTvShowProgress(tvDetails), [tvDetails]);
 
 	const { data: movieRating } = useMovieRating(username, tmdbId);
 	const { data: tvRating } = useTvRating(username, tmdbId);
@@ -78,15 +74,14 @@ export const MediaActionMenu = ({
 			});
 		}
 
-		const episodeInfo = getLastAiredEpisodeInfo(tvDetails);
-		if (!episodeInfo) return;
+		if (!tvProgress?.lastAired) return;
 
 		rateTvMutation.mutate({
 			tmdbId,
 			rating: newRating,
 			review: null,
-			lastWatchedSeason: episodeInfo.seasonNumber,
-			lastWatchedEpisode: episodeInfo.episodeNumber,
+			lastWatchedSeason: tvProgress.lastAired.seasonNumber,
+			lastWatchedEpisode: tvProgress.lastAired.episodeNumber,
 			absoluteEpisode: null,
 			trackingMode: "season",
 			watchedAt: new Date(),
@@ -129,7 +124,7 @@ export const MediaActionMenu = ({
 				</CardHeader>
 				<CardContent className="flex flex-col gap-2">
 					<LogReviewButton
-						existingRating={existingRating ? true : false}
+						existingRating={!!existingRating}
 						onClick={() => setShowLogReviewDialog(true)}
 					/>
 					<AddToListButton onClick={() => setShowAddToListDialog(true)} />

--- a/apps/frontend/src/components/lists/media-actions/season-episode-combobox.tsx
+++ b/apps/frontend/src/components/lists/media-actions/season-episode-combobox.tsx
@@ -17,10 +17,11 @@ interface Season {
 
 interface SeasonEpisodeComboboxProps {
 	seasons: Season[];
-	selectedSeason: string;
-	selectedEpisode: string;
-	onSeasonChange: (value: string) => void;
-	onEpisodeChange: (value: string) => void;
+	selectedSeason: number | null;
+	selectedEpisode: number | null;
+	onSeasonChange: (value: number | null) => void;
+	onEpisodeChange: (value: number | null) => void;
+	lastAired?: { seasonNumber: number; episodeNumber: number } | null;
 }
 
 export function SeasonEpisodeCombobox({
@@ -29,40 +30,47 @@ export function SeasonEpisodeCombobox({
 	selectedEpisode,
 	onSeasonChange,
 	onEpisodeChange,
+	lastAired,
 }: SeasonEpisodeComboboxProps) {
-	const [seasonInputValue, setSeasonInputValue] = useState(selectedSeason);
-	const [episodeInputValue, setEpisodeInputValue] = useState(selectedEpisode);
 	const [seasonOpen, setSeasonOpen] = useState(false);
 	const [episodeOpen, setEpisodeOpen] = useState(false);
 
-	const seasonNumbers = useMemo(
-		() => seasons.map((s) => s.season_number),
+	// Only show seasons that have aired (≤ lastAired.seasonNumber)
+	const availableSeasons = useMemo(() => {
+		if (!lastAired) return [];
+		return seasons.filter((s) => s.season_number <= lastAired.seasonNumber);
+	}, [seasons, lastAired]);
+
+	// Lookup for total episodes per season (for earlier seasons)
+	const seasonEpisodeCountMap = useMemo(
+		() => new Map(seasons.map((s) => [s.season_number, s.episode_count])),
 		[seasons],
 	);
 
-	const availableEpisodes = selectedSeason
-		? seasons.find((s) => s.season_number === Number(selectedSeason))
-				?.episode_count || 0
-		: 0;
+	// Helper to get max selectable episode for a season
+	const getMaxEpisode = (seasonNum: number): number => {
+		if (!lastAired) return 0;
+		if (seasonNum < lastAired.seasonNumber) {
+			// All episodes of this season have aired
+			return seasonEpisodeCountMap.get(seasonNum) ?? 0;
+		} else if (seasonNum === lastAired.seasonNumber) {
+			// Only up to the last aired episode
+			return lastAired.episodeNumber;
+		}
+		return 0;
+	};
+
+	// Number of episodes available for the selected season
+	const availableEpisodes = useMemo(() => {
+		if (!selectedSeason) return 0;
+		const seasonNum = Number(selectedSeason);
+		return getMaxEpisode(seasonNum);
+	}, [selectedSeason, lastAired, seasonEpisodeCountMap]);
 
 	const episodeNumbers = useMemo(
 		() => Array.from({ length: availableEpisodes }, (_, i) => i + 1),
 		[availableEpisodes],
 	);
-
-	const filteredSeasons = useMemo(() => {
-		if (!seasonInputValue) return seasonNumbers;
-		return seasonNumbers.filter((num) =>
-			num.toString().includes(seasonInputValue),
-		);
-	}, [seasonNumbers, seasonInputValue]);
-
-	const filteredEpisodes = useMemo(() => {
-		if (!episodeInputValue) return episodeNumbers;
-		return episodeNumbers.filter((num) =>
-			num.toString().includes(episodeInputValue),
-		);
-	}, [episodeNumbers, episodeInputValue]);
 
 	return (
 		<div className="flex flex-col gap-4 lg:flex-row">
@@ -73,30 +81,30 @@ export function SeasonEpisodeCombobox({
 					onOpenChange={setSeasonOpen}
 					value={selectedSeason}
 					onValueChange={(val) => {
-						const newValue = val ?? "";
+						const newValue = val ?? null;
 						onSeasonChange(newValue);
 						if (newValue !== selectedSeason) {
-							onEpisodeChange("");
+							onEpisodeChange(null);
 						}
-						if (val) setSeasonInputValue(val);
 					}}
-					inputValue={seasonInputValue}
-					onInputValueChange={setSeasonInputValue}
 				>
 					<ComboboxInput
 						placeholder={m.log_review_dialog_season_combobox_placeholder()}
 						showClear={!!selectedSeason}
 					/>
 					<ComboboxContent>
-						{filteredSeasons.length === 0 ? (
+						{availableSeasons.length === 0 ? (
 							<ComboboxEmpty>
 								{m.log_review_dialog_season_combobox_no_result()}
 							</ComboboxEmpty>
 						) : null}
 						<ComboboxList>
-							{filteredSeasons.map((seasonNum) => (
-								<ComboboxItem key={seasonNum} value={seasonNum.toString()}>
-									{seasonNum}
+							{availableSeasons.map((season) => (
+								<ComboboxItem
+									key={season.season_number}
+									value={season.season_number.toString()}
+								>
+									{season.season_number}
 								</ComboboxItem>
 							))}
 						</ComboboxList>
@@ -111,26 +119,23 @@ export function SeasonEpisodeCombobox({
 					onOpenChange={setEpisodeOpen}
 					value={selectedEpisode}
 					onValueChange={(val) => {
-						onEpisodeChange(val ?? "");
-						if (val) setEpisodeInputValue(val);
+						onEpisodeChange(val ?? null);
 					}}
-					inputValue={episodeInputValue}
-					onInputValueChange={setEpisodeInputValue}
-					disabled={!selectedSeason}
+					disabled={!selectedSeason || availableEpisodes === 0}
 				>
 					<ComboboxInput
 						placeholder={m.log_review_dialog_episode_combobox_placeholder()}
 						showClear={!!selectedEpisode}
-						disabled={!selectedSeason}
+						disabled={!selectedSeason || availableEpisodes === 0}
 					/>
 					<ComboboxContent>
-						{filteredEpisodes.length === 0 ? (
+						{episodeNumbers.length === 0 ? (
 							<ComboboxEmpty>
 								{m.log_review_dialog_episode_combobox_no_result()}
 							</ComboboxEmpty>
 						) : null}
 						<ComboboxList>
-							{filteredEpisodes.map((episodeNum) => (
+							{episodeNumbers.map((episodeNum) => (
 								<ComboboxItem key={episodeNum} value={episodeNum.toString()}>
 									{episodeNum}
 								</ComboboxItem>

--- a/apps/frontend/src/components/lists/media-actions/watch-toggle-button.tsx
+++ b/apps/frontend/src/components/lists/media-actions/watch-toggle-button.tsx
@@ -1,6 +1,6 @@
 import { IconEye, IconEyeFilled, IconEyeOff } from "@tabler/icons-react";
 import { useAtomValue } from "jotai";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
 	useAddMovieToHistory,
 	useAddTvToHistory,
@@ -11,7 +11,7 @@ import { useMovieRating, useTvRating } from "@/hooks/useRating";
 import { useTv } from "@/hooks/useTv";
 import { localeRegionAtom } from "@/lib/atoms/region";
 import { m } from "@/paraglide/messages";
-import { getLastAiredEpisodeInfo } from "@/utils/season-helper";
+import { getTvShowProgress } from "@/utils/season-helper";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { RemoveHistoryAlertDialog } from "./remove-history-alert-dialog";
 
@@ -49,6 +49,8 @@ export function WatchToggleButton({
 		{ enabled: !!tvShow?.id },
 	);
 
+	const tvProgress = useMemo(() => getTvShowProgress(tvDetails), [tvDetails]);
+
 	const movieRating = useMovieRating(username, movie?.id ?? 0);
 	const tvRating = useTvRating(username, tvShow?.id ?? 0);
 
@@ -82,14 +84,14 @@ export function WatchToggleButton({
 					review: null,
 					watchedAt: date,
 				});
-			} else if (tvShow) {
-				const episodeInfo = getLastAiredEpisodeInfo(tvDetails);
+			} else if (tvShow && tvProgress?.lastAired) {
+				const { lastAired } = tvProgress;
 				addTvToHistory.mutate({
 					tmdbId: tvShow.id,
 					rating: null,
 					review: null,
-					lastWatchedSeason: episodeInfo?.seasonNumber ?? null,
-					lastWatchedEpisode: episodeInfo?.episodeNumber ?? null,
+					lastWatchedSeason: lastAired.seasonNumber,
+					lastWatchedEpisode: lastAired.episodeNumber,
 					absoluteEpisode: null,
 					trackingMode: "season",
 					watchedAt: date,

--- a/apps/frontend/src/utils/season-helper.ts
+++ b/apps/frontend/src/utils/season-helper.ts
@@ -19,7 +19,7 @@ interface TvDetails {
 }
 
 /**
- * Detects if a TV show uses continuous/absolute episode numbering
+ * Tries to detects if a TV show uses continuous/absolute episode numbering
  * (common in anime) vs per-season numbering (common in western TV shows)
  */
 export function getHasContinuousEpisodeNumbering(
@@ -32,35 +32,22 @@ export function getHasContinuousEpisodeNumbering(
 	const lastEpisode = tvDetails.last_episode_to_air;
 	const { season_number, episode_number } = lastEpisode;
 
-	// Calculate total episodes before this season
-	const episodesBeforeSeason = tvDetails.seasons
-		.filter((s) => s.season_number > 0 && s.season_number < season_number)
-		.reduce((sum, s) => sum + s.episode_count, 0);
-
-	// If episode_number is much larger than episodes in current season,
-	// it's likely using continuous numbering
 	const currentSeason = tvDetails.seasons.find(
 		(s) => s.season_number === season_number,
 	);
 
 	if (!currentSeason) return false;
 
-	// If episode number exceeds current season's episode count,
-	// it's definitely continuous numbering
-	if (episode_number > currentSeason.episode_count) {
-		return true;
-	}
+	// Calculate total episodes before this season
+	const episodesBeforeSeason = tvDetails.seasons
+		.filter((s) => s.season_number > 0 && s.season_number < season_number)
+		.reduce((sum, s) => sum + s.episode_count, 0);
 
-	// Additional check: if the episode number is close to total episodes
-	// accumulated up to this season, it's continuous numbering
-	const expectedContinuousEpisode = episodesBeforeSeason + episode_number;
-	const totalEpisodes = tvDetails.number_of_episodes ?? 0;
-
-	// If we're close to the total and episode number is high, likely continuous
-	return (
-		episode_number > 100 &&
-		Math.abs(expectedContinuousEpisode - totalEpisodes) < 50
-	);
+	// If episode_number > all previous episodes, it's counting from episode 1 (continuous)
+	// Ex: One Piece S22E1155 - there were ~1100 episodes before S22, so 1155 > 1100
+	// If episode_number < all previous episodes, it restarted counting each season (per-season)
+	// Ex: Plus belle la vie S18E310 - there were > 4000 episodes before S18, so 310 < 4300
+	return episode_number > episodesBeforeSeason;
 }
 
 export function getValidSeasons(seasons: Season[] | undefined): Season[] {
@@ -84,7 +71,6 @@ export function getLastAiredEpisodeInfo(tvDetails: TvDetails | undefined): {
 
 	const { season_number, episode_number } = tvDetails.last_episode_to_air;
 
-	// For shows with continuous episode numbering, calculate the episode within the season
 	const season = tvDetails.seasons?.find(
 		(s) => s.season_number === season_number,
 	);
@@ -98,6 +84,15 @@ export function getLastAiredEpisodeInfo(tvDetails: TvDetails | undefined): {
 
 		// Episode number within current season
 		const episodeInSeason = episode_number - episodesBeforeSeason;
+
+		// If calculation produces invalid result, fall back to raw episode_number
+		// (happens when TMDB data is inconsistent about numbering scheme)
+		if (episodeInSeason <= 0 || episodeInSeason > season.episode_count) {
+			return {
+				seasonNumber: season_number,
+				episodeNumber: Math.min(episode_number, season.episode_count),
+			};
+		}
 
 		return {
 			seasonNumber: season_number,

--- a/apps/frontend/src/utils/season-helper.ts
+++ b/apps/frontend/src/utils/season-helper.ts
@@ -19,89 +19,75 @@ interface TvDetails {
 }
 
 /**
- * Tries to detects if a TV show uses continuous/absolute episode numbering
- * (common in anime) vs per-season numbering (common in western TV shows)
+ * Filters out Season 0 (Specials) and any seasons that haven't aired yet.
  */
-export function getHasContinuousEpisodeNumbering(
-	tvDetails: TvDetails | undefined,
-): boolean {
-	if (!tvDetails?.last_episode_to_air || !tvDetails.seasons) {
-		return false;
-	}
-
-	const lastEpisode = tvDetails.last_episode_to_air;
-	const { season_number, episode_number } = lastEpisode;
-
-	const currentSeason = tvDetails.seasons.find(
-		(s) => s.season_number === season_number,
-	);
-
-	if (!currentSeason) return false;
-
-	// Calculate total episodes before this season
-	const episodesBeforeSeason = tvDetails.seasons
-		.filter((s) => s.season_number > 0 && s.season_number < season_number)
-		.reduce((sum, s) => sum + s.episode_count, 0);
-
-	// If episode_number > all previous episodes, it's counting from episode 1 (continuous)
-	// Ex: One Piece S22E1155 - there were ~1100 episodes before S22, so 1155 > 1100
-	// If episode_number < all previous episodes, it restarted counting each season (per-season)
-	// Ex: Plus belle la vie S18E310 - there were > 4000 episodes before S18, so 310 < 4300
-	return episode_number > episodesBeforeSeason;
-}
-
 export function getValidSeasons(seasons: Season[] | undefined): Season[] {
 	if (!seasons) return [];
 
 	const now = new Date();
-
-	return seasons.filter((season) => {
-		if (season.season_number === 0) return false;
-		// Only filter by air_date if it exists
-		if (season.air_date && new Date(season.air_date) > now) return false;
-		return true;
-	});
+	return seasons.filter(
+		(s) => s.season_number > 0 && (!s.air_date || new Date(s.air_date) <= now),
+	);
 }
 
-export function getLastAiredEpisodeInfo(tvDetails: TvDetails | undefined): {
-	seasonNumber: number;
-	episodeNumber: number;
-} | null {
-	if (!tvDetails?.last_episode_to_air) return null;
+/**
+ * Returns a unified object containing the normalized last episode
+ * and the list of valid seasons.
+ */
+export function getTvShowProgress(tvDetails: TvDetails | undefined) {
+	if (!tvDetails) return null;
 
-	const { season_number, episode_number } = tvDetails.last_episode_to_air;
+	const validSeasons = getValidSeasons(tvDetails.seasons);
+	const lastEp = tvDetails.last_episode_to_air;
 
-	const season = tvDetails.seasons?.find(
-		(s) => s.season_number === season_number,
-	);
+	if (!lastEp) {
+		return { validSeasons, lastAired: null };
+	}
 
-	if (season && getHasContinuousEpisodeNumbering(tvDetails)) {
-		// Calculate episodes before this season
-		const episodesBeforeSeason =
-			tvDetails.seasons
-				?.filter((s) => s.season_number > 0 && s.season_number < season_number)
-				.reduce((sum, s) => sum + s.episode_count, 0) ?? 0;
+	const { season_number: lastSznNum, episode_number: lastEpNum } = lastEp;
 
-		// Episode number within current season
-		const episodeInSeason = episode_number - episodesBeforeSeason;
+	let episodesBefore = 0;
+	let currentSeasonTotal = 0;
 
-		// If calculation produces invalid result, fall back to raw episode_number
-		// (happens when TMDB data is inconsistent about numbering scheme)
-		if (episodeInSeason <= 0 || episodeInSeason > season.episode_count) {
-			return {
-				seasonNumber: season_number,
-				episodeNumber: Math.min(episode_number, season.episode_count),
-			};
+	(tvDetails.seasons || []).forEach((s) => {
+		if (s.season_number > 0 && s.season_number < lastSznNum) {
+			episodesBefore += s.episode_count;
+		} else if (s.season_number === lastSznNum) {
+			currentSeasonTotal = s.episode_count;
 		}
+	});
 
-		return {
-			seasonNumber: season_number,
-			episodeNumber: Math.min(episodeInSeason, season.episode_count),
-		};
+	/**
+	 * Logic: Only consider "Continuous Numbering" if:
+	 * 1. We are beyond Season 1.
+	 * 2. The episode number is greater than the total episodes in the current season.
+	 * 3. The episode number looks like an absolute count (greater than episodes before).
+	 */
+	const isContinuous =
+		lastSznNum > 1 &&
+		lastEpNum > currentSeasonTotal &&
+		lastEpNum > episodesBefore;
+
+	let normalizedEpisode = lastEpNum;
+
+	if (isContinuous) {
+		const calculated = lastEpNum - episodesBefore;
+		// If the subtraction results in a valid episode index, use it.
+		// Otherwise, fallback to the provided number or the season cap.
+		normalizedEpisode = calculated > 0 ? calculated : lastEpNum;
+	}
+
+	// Final safety: never let the episode number exceed the season's episode count
+	if (currentSeasonTotal > 0) {
+		normalizedEpisode = Math.min(normalizedEpisode, currentSeasonTotal);
 	}
 
 	return {
-		seasonNumber: season_number,
-		episodeNumber: episode_number,
+		validSeasons,
+		lastAired: {
+			seasonNumber: lastSznNum,
+			episodeNumber: normalizedEpisode,
+			isContinuous,
+		},
 	};
 }

--- a/apps/frontend/src/utils/utils.ts
+++ b/apps/frontend/src/utils/utils.ts
@@ -1,6 +1,3 @@
-export const getNumberOrNull = (value: string) =>
-	value ? Number(value) : null;
-
 export type ImageSize = "w200" | "w500" | "original";
 
 export const getTmdbImageUrl = (


### PR DESCRIPTION
- simplify the check for absolute episode, instead of guessing around, just check if the episode number is greater than the number of episodes in the current season and the season is greater than 1
- fix data given by backend for history in tv show: adds episode number, season number and absolute episode number (if needed), it also fix the log review dialog not being filled when data already existed
- fix types in frontend for episode number, season number and absolute number (from string | null to number | null)