### PR TITLE
feat: update collections

### DIFF
--- a/apps/backend/src/web/validators/query-param.ts
+++ b/apps/backend/src/web/validators/query-param.ts
@@ -173,6 +173,7 @@ const appendOptions = z.union([
 	z.literal("combined_credits"),
 	z.literal("external_ids"),
 	z.literal("translations"),
+	z.literal("credits"),
 	z.literal("combined_credits,external_ids"),
 	z.literal("external_ids,combined_credits"),
 	z.literal("combined_credits,translations"),

--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -723,5 +723,7 @@
 	"btn_go_back": "Go back",
 	"btn_go_to_history_page": "View",
 	"btn_go_to_watchlist": "View",
-	"btn_go_to_favorites": "View"
+	"btn_go_to_favorites": "View",
+	"cast_text": "Cast",
+	"crew_text": "Crew"
 }

--- a/apps/frontend/messages/fr.json
+++ b/apps/frontend/messages/fr.json
@@ -721,5 +721,7 @@
 	"btn_go_back": "Retour en arrière",
 	"btn_go_to_history_page": "Voir",
 	"btn_go_to_watchlist": "Voir",
-	"btn_go_to_favorites": "Voir"
+	"btn_go_to_favorites": "Voir",
+	"cast_text": "Distribution",
+	"crew_text": "Équipe technique"
 }

--- a/apps/frontend/src/components/collections/collection-card.tsx
+++ b/apps/frontend/src/components/collections/collection-card.tsx
@@ -27,7 +27,7 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 
 	return (
 		<Card
-			className="relative overflow-hidden min-h-[200px] justify-center text-dark-card-foreground"
+			className="relative overflow-hidden min-h-[200px] ring-0 justify-center text-dark-card-foreground"
 			style={
 				backgroundImage
 					? {
@@ -47,17 +47,17 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<Button
-					variant="outline"
-					className="w-full lg:w-1/2 xl:w-1/3 text-foreground"
+				<Link
+					to="/collections/$collectionId"
+					params={{ collectionId: collection.id.toString() }}
 				>
-					<Link
-						to="/collections/$collectionId"
-						params={{ collectionId: collection.id.toString() }}
+					<Button
+						variant="secondary"
+						className="w-full md:w-xs text-foreground"
 					>
 						{m.btn_view_collection()}
-					</Link>
-				</Button>
+					</Button>
+				</Link>
 			</CardContent>
 		</Card>
 	);

--- a/apps/frontend/src/components/collections/collection-details.tsx
+++ b/apps/frontend/src/components/collections/collection-details.tsx
@@ -1,20 +1,20 @@
 import type { Schemas } from "shared";
 import { ResourceNotFound } from "@/components/errors/resource-not-found";
 import { LoadingCentered } from "@/components/loading/loading-centered";
+import { MediaBackgroundImage } from "@/components/medias/media-background-image";
 import { MediaOverview } from "@/components/medias/media-overview";
 import { MediaPortraitImage } from "@/components/medias/media-portrait-image";
 import { MovieCarousel } from "@/components/movies/movie-carousel";
 import { BackButton } from "@/components/ui/back-button";
 import { Badge } from "@/components/ui/badge";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { m } from "@/paraglide/messages";
-import { getTmdbImageUrl } from "@/utils/utils";
+import {
+	getTmdbImageUrl,
+	mergeCastMemberCharacters,
+	mergeCrewMemberJobs,
+} from "@/utils/utils";
+import { CastCrewTabs } from "../person/cast-crew-tabs";
 
 interface CollectionDetailsViewProps {
 	collectionData: Schemas.CollectionDetails | undefined;
@@ -23,8 +23,6 @@ interface CollectionDetailsViewProps {
 	isError: boolean;
 }
 
-// @todo: rework this page (move the background_path to the top etc etc)
-// probably get rid of the budget and earning as this is not very relevant / not always accurate data
 export function CollectionDetailsView({
 	collectionData,
 	moviesData,
@@ -44,45 +42,51 @@ export function CollectionDetailsView({
 		);
 	}
 
-	const collectionStats = moviesData.reduce(
+	const moviesAggregate = moviesData.reduce(
 		(acc, movie) => {
-			if (movie?.revenue) {
-				acc.totalRevenue += movie.revenue;
-			}
+			if (!movie) return acc;
 
-			if (movie?.genres) {
+			if (movie.genres) {
 				movie.genres.forEach((genre) => {
-					if (!acc.genres.some((g) => g.id === genre.id)) {
+					const exists = acc.genres.some((g) => g.id === genre.id);
+					if (!exists) {
 						acc.genres.push(genre);
 					}
 				});
 			}
 
+			if (movie.credits?.cast) {
+				const leadRoles = movie.credits.cast.slice(0, 10);
+				leadRoles.forEach((castMember) =>
+					mergeCastMemberCharacters(acc.cast, castMember),
+				);
+			}
+
+			if (movie.credits?.crew) {
+				const filteredCrew = movie.credits.crew.filter(
+					(crewMember) =>
+						crewMember.department === "Writing" ||
+						crewMember.job === "Director",
+				);
+				filteredCrew.forEach((crewMember) =>
+					mergeCrewMemberJobs(acc.crew, crewMember),
+				);
+			}
+
 			return acc;
 		},
 		{
-			totalRevenue: 0,
 			genres: [] as Array<{ id: number; name: string }>,
+			cast: [] as Array<Schemas.CastMember & { characters?: string[] }>,
+			crew: [] as Array<Schemas.CrewMember & { jobs?: string[] }>,
 		},
 	);
 
-	const formattedRevenue = new Intl.NumberFormat("en-US", {
-		style: "currency",
-		currency: "USD",
-		minimumFractionDigits: 0,
-		maximumFractionDigits: 0,
-	}).format(collectionStats.totalRevenue);
-
-	const totalBudget = moviesData.reduce((sum, movie) => {
-		return sum + (movie?.budget ?? 0);
-	}, 0);
-
-	const formattedBudget = new Intl.NumberFormat("en-US", {
-		style: "currency",
-		currency: "USD",
-		minimumFractionDigits: 0,
-		maximumFractionDigits: 0,
-	}).format(totalBudget);
+	const sortedAggregate = {
+		genres: moviesAggregate.genres,
+		cast: moviesAggregate.cast,
+		crew: moviesAggregate.crew,
+	};
 
 	const sortedParts = [...collectionData.parts].sort((a, b) => {
 		const dateA = a.release_date
@@ -100,80 +104,57 @@ export function CollectionDetailsView({
 	);
 
 	return (
-		<div className="container">
-			<BackButton />
+		<>
+			<MediaBackgroundImage backgroundImage={backgroundImage} />
+			<div className="container pt-3 md:pt-10 lg:pt-50">
+				<BackButton />
 
-			<div className="flex flex-col gap-4 pt-2">
-				<Card
-					className="relative overflow-hidden min-h-[200px] justify-center text-dark-card-foreground"
-					style={
-						backgroundImage
-							? {
-									backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.8)), url(${backgroundImage})`,
-									backgroundSize: "cover",
-									backgroundPosition: "center",
-								}
-							: undefined
-					}
-				>
-					<div className="flex flex-col md:flex-row gap-6 p-6 items-center md:items-start">
-						<div className="flex justify-center md:justify-start">
-							<MediaPortraitImage
-								imagePath={collectionData.poster_path}
-								alt={collectionData.name}
-								imageSize="w500"
-							/>
-						</div>
-
-						<div className="flex-1">
-							<CardHeader className="p-0 pb-4">
-								<CardTitle className="text-2xl">
-									{collectionData.name}
-								</CardTitle>
-								<CardDescription className="flex flex-wrap gap-2">
-									{collectionStats.genres.map((genre) => (
-										<Badge
-											key={genre.id}
-											variant="outline"
-											className="text-dark-card-foreground"
-										>
-											{genre.name}
-										</Badge>
-									))}
-								</CardDescription>
-							</CardHeader>
-							<CardContent className="p-0 flex flex-col gap-2">
-								<MediaOverview overview={collectionData.overview} />
-
-								{totalBudget > 0 ? (
-									<div className="flex gap-2">
-										<h3 className="text-semi-bold text-md">
-											{m.collection_details_budget()}
-										</h3>
-										<p>{formattedBudget}</p>
-									</div>
-								) : null}
-
-								{collectionStats.totalRevenue > 0 ? (
-									<div className="flex gap-2">
-										<h3 className="text-semi-bold text-md">
-											{m.collection_details_revenue()}
-										</h3>
-										<p>{formattedRevenue}</p>
-									</div>
-								) : null}
-							</CardContent>
-						</div>
+				<div className="grid lg:grid-cols-[auto_1fr] gap-2 lg:gap-4 pt-2 justify-items-center">
+					<div className="flex flex-col gap-2 items-center lg:items-start max-w-[250px] md:max-w-[300px] lg:max-w-[400px]">
+						<MediaPortraitImage
+							imagePath={collectionData.poster_path}
+							alt={collectionData.name}
+							imageSize="w500"
+						/>
 					</div>
-				</Card>
 
-				<MovieCarousel
-					title={m.collection_carousel_title({
-						number: collectionData.parts.length,
-					})}
-					movies={sortedParts}
-				/>
+					<div className="w-full flex flex-col gap-4 overflow-hidden">
+						<Card className="shadow-none bg-transparent border-none ring-0 lg:p-0">
+							<CardContent className="p-0">
+								<div className="flex flex-col gap-2 px-0.5 py-0.5">
+									<h1 className="text-2xl lg:text-4xl font-bold leading-relaxed">
+										{collectionData.name}
+									</h1>
+
+									<div className="flex flex-wrap gap-2">
+										{sortedAggregate.genres.map((genre) => (
+											<Badge key={genre.id} variant="outline">
+												{genre.name}
+											</Badge>
+										))}
+									</div>
+
+									<div className="flex flex-col gap-1">
+										<MediaOverview overview={collectionData.overview} />
+									</div>
+								</div>
+							</CardContent>
+						</Card>
+
+						<MovieCarousel
+							title={m.collection_carousel_title({
+								number: collectionData.parts.length,
+							})}
+							movies={sortedParts}
+						/>
+
+						<CastCrewTabs
+							cast={sortedAggregate.cast}
+							crew={sortedAggregate.crew}
+						/>
+					</div>
+				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/apps/frontend/src/components/movies/movie-details.tsx
+++ b/apps/frontend/src/components/movies/movie-details.tsx
@@ -220,39 +220,38 @@ export function MovieDetailView({
 
 						{collection ? <CollectionCard collection={collection} /> : null}
 
-						{movie.production_companies
-							? movie.production_companies.length > 0 && (
-									<Card className="border ring-0">
-										<CardHeader>
-											<CardTitle>
-												{m.movie_details_production_companies({
-													count: movie.production_companies.length,
-												})}
-											</CardTitle>
-										</CardHeader>
+						{movie.production_companies &&
+						movie.production_companies.length > 0 ? (
+							<Card className="border ring-0">
+								<CardHeader>
+									<CardTitle>
+										{m.movie_details_production_companies({
+											count: movie.production_companies.length,
+										})}
+									</CardTitle>
+								</CardHeader>
 
-										<CardContent className="flex flex-wrap gap-4">
-											{movie.production_companies.map(
-												(company: Schemas.ProductionCompany) => (
-													<Badge
-														key={company.id}
-														className="flex items-center gap-2"
-														variant="outline"
-													>
-														{company.origin_country ? (
-															<span
-																className={`fi fi-${company.origin_country.toLocaleLowerCase()}`}
-																style={{ width: 18, height: 14 }}
-															/>
-														) : null}
-														<span className="font-medium">{company.name}</span>
-													</Badge>
-												),
-											)}
-										</CardContent>
-									</Card>
-								)
-							: null}
+								<CardContent className="flex flex-wrap gap-4">
+									{movie.production_companies.map(
+										(company: Schemas.ProductionCompany) => (
+											<Badge
+												key={company.id}
+												className="flex items-center gap-2"
+												variant="outline"
+											>
+												{company.origin_country ? (
+													<span
+														className={`fi fi-${company.origin_country.toLocaleLowerCase()}`}
+														style={{ width: 18, height: 14 }}
+													/>
+												) : null}
+												<span className="font-medium">{company.name}</span>
+											</Badge>
+										),
+									)}
+								</CardContent>
+							</Card>
+						) : null}
 					</div>
 				</div>
 			</div>

--- a/apps/frontend/src/components/person/cast-crew-tabs.tsx
+++ b/apps/frontend/src/components/person/cast-crew-tabs.tsx
@@ -1,0 +1,27 @@
+import type { Schemas } from "shared";
+import { m } from "@/paraglide/messages";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { CastList } from "./cast-list";
+import { CrewList } from "./crew-list";
+
+interface CastCrewTabsProps {
+	cast: Array<Schemas.CastMember & { characters?: string[] }> | [];
+	crew: Array<Schemas.CrewMember & { jobs?: string[] }> | [];
+}
+
+export function CastCrewTabs({ cast, crew }: CastCrewTabsProps) {
+	return (
+		<Tabs defaultValue="cast" className="w-full">
+			<TabsList>
+				<TabsTrigger value="cast">{m.cast_text()}</TabsTrigger>
+				<TabsTrigger value="crew">{m.crew_text()}</TabsTrigger>
+			</TabsList>
+			<TabsContent value="cast">
+				<CastList people={cast} />
+			</TabsContent>
+			<TabsContent value="crew">
+				<CrewList people={crew} />
+			</TabsContent>
+		</Tabs>
+	);
+}

--- a/apps/frontend/src/components/person/cast-hover-card.tsx
+++ b/apps/frontend/src/components/person/cast-hover-card.tsx
@@ -20,15 +20,17 @@ import { m } from "@/paraglide/messages";
 import { Button } from "../ui/button";
 
 interface CastHoverCardProps {
-	person: Schemas.CastMember;
+	person: Schemas.CastMember & { characters?: string[] };
 }
 
 export const CastHoverCard = ({ person }: CastHoverCardProps) => {
 	const isMobile = useMediaQuery("(pointer: coarse)");
 	const personName = person.name;
-	const character = person.character
-		? `${m.person_as()} ${person.character}`
-		: "N/A";
+	const characterText = person.characters?.length
+		? `${m.person_as()} ${person.characters.join(", ")}`
+		: person.character
+			? `${m.person_as()} ${person.character}`
+			: "N/A";
 	const imageUrl = person.profile_path
 		? `https://image.tmdb.org/t/p/w500${person.profile_path}`
 		: null;
@@ -58,7 +60,7 @@ export const CastHoverCard = ({ person }: CastHoverCardProps) => {
 								{personName}
 							</DrawerTitle>
 							<DrawerDescription className="wrap-break-words">
-								{character}
+								{characterText}
 							</DrawerDescription>
 						</div>
 					</div>
@@ -102,7 +104,7 @@ export const CastHoverCard = ({ person }: CastHoverCardProps) => {
 							</p>
 							<IconExternalLink size={14} className="shrink-0 mt-0.5" />
 						</div>
-						<p className="text-xs text-muted-foreground">{character}</p>
+						<p className="text-xs text-muted-foreground">{characterText}</p>
 					</div>
 				</Link>
 			</HoverCardContent>

--- a/apps/frontend/src/components/person/cast-list.tsx
+++ b/apps/frontend/src/components/person/cast-list.tsx
@@ -2,7 +2,7 @@ import type { Schemas } from "shared";
 import { CastHoverCard } from "@/components/person/cast-hover-card";
 
 interface CastListProps {
-	people: Schemas.CastMember[];
+	people: Array<Schemas.CastMember & { characters?: string[] }>;
 }
 
 export const CastList = ({ people }: CastListProps) => {

--- a/apps/frontend/src/components/person/crew-hover-card.tsx
+++ b/apps/frontend/src/components/person/crew-hover-card.tsx
@@ -1,0 +1,113 @@
+import { IconExternalLink } from "@tabler/icons-react"; // or whichever icon you want
+import { Link } from "@tanstack/react-router";
+import type { Schemas } from "shared";
+import { Badge } from "@/components/ui/badge";
+import {
+	Drawer,
+	DrawerContent,
+	DrawerDescription,
+	DrawerFooter,
+	DrawerTitle,
+	DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+	HoverCard,
+	HoverCardContent,
+	HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { useMediaQuery } from "@/integrations/media-query";
+import { m } from "@/paraglide/messages";
+import { Button } from "../ui/button";
+
+interface CrewHoverCardProps {
+	person: Schemas.CrewMember & { jobs?: string[] };
+}
+
+export const CrewHoverCard = ({ person }: CrewHoverCardProps) => {
+	const isMobile = useMediaQuery("(pointer: coarse)");
+	const personName = person.name;
+	const jobsText = person.jobs?.length
+		? person.jobs.join(", ")
+		: person.job
+			? person.job
+			: "N/A";
+	const imageUrl = person.profile_path
+		? `https://image.tmdb.org/t/p/w500${person.profile_path}`
+		: null;
+
+	const handleImageError = (e: React.SyntheticEvent<HTMLImageElement>) => {
+		e.currentTarget.style.display = "none";
+	};
+
+	if (isMobile) {
+		return (
+			<Drawer swipeDirection="down">
+				<DrawerTrigger>
+					<Badge>{personName}</Badge>
+				</DrawerTrigger>
+				<DrawerContent className="items-center">
+					<div className="flex gap-4 pt-6 pb-2 px-4">
+						{imageUrl ? (
+							<img
+								src={imageUrl}
+								alt={personName}
+								onError={handleImageError}
+								className="w-20 h-auto aspect-2/3 object-cover rounded-lg shrink-0"
+							/>
+						) : null}
+						<div className="flex flex-col justify-center gap-1 flex-1">
+							<DrawerTitle className="wrap-break-words">
+								{personName}
+							</DrawerTitle>
+							<DrawerDescription className="wrap-break-words">
+								{jobsText}
+							</DrawerDescription>
+						</div>
+					</div>
+					<DrawerFooter className="w-full mb-2">
+						<Link
+							to="/person/$personId"
+							params={{ personId: person.id.toString() }}
+							className="w-full"
+						>
+							<Button className="w-full">{m.btn_media_learn_more()}</Button>
+						</Link>
+					</DrawerFooter>
+				</DrawerContent>
+			</Drawer>
+		);
+	}
+
+	return (
+		<HoverCard>
+			<HoverCardTrigger
+				render={<Badge className="cursor-default">{personName}</Badge>}
+			/>
+			<HoverCardContent className="w-40 p-0" side="left" align="end">
+				<Link
+					to="/person/$personId"
+					params={{ personId: person.id.toString() }}
+					className="block"
+				>
+					{imageUrl ? (
+						<img
+							src={imageUrl}
+							alt={personName}
+							onError={handleImageError}
+							className="w-full h-auto aspect-2/3 object-cover rounded-t-md"
+						/>
+					) : null}
+					<div className="p-2 space-y-1">
+						<div className="flex items-start gap-1">
+							<p className="font-semibold text-xs flex-1 wrap-break-words">
+								{personName}
+							</p>
+							<IconExternalLink size={14} className="shrink-0 mt-0.5" />
+						</div>
+						<p className="text-xs text-muted-foreground">{jobsText}</p>
+					</div>
+				</Link>
+			</HoverCardContent>
+		</HoverCard>
+	);
+};

--- a/apps/frontend/src/components/person/crew-list.tsx
+++ b/apps/frontend/src/components/person/crew-list.tsx
@@ -1,0 +1,18 @@
+import type { Schemas } from "shared";
+import { CrewHoverCard } from "./crew-hover-card";
+
+interface CrewListProps {
+	people: Array<Schemas.CrewMember & { jobs?: string[] }>;
+}
+
+export const CrewList = ({ people }: CrewListProps) => {
+	if (!people.length) return null;
+
+	return (
+		<div className="flex flex-wrap gap-2">
+			{people.map((person) => (
+				<CrewHoverCard key={person.id} person={person} />
+			))}
+		</div>
+	);
+};

--- a/apps/frontend/src/routes/collections/$collectionId.tsx
+++ b/apps/frontend/src/routes/collections/$collectionId.tsx
@@ -26,7 +26,12 @@ function CollectionDetailsPage() {
 		queries:
 			collectionData?.parts?.map((movie: Schemas.MovieDetails) => ({
 				queryKey: ["movie", movie.id, localeRegion],
-				queryFn: () => fetchMovie(movie.id, { language: localeRegion, region }),
+				queryFn: () =>
+					fetchMovie(movie.id, {
+						language: localeRegion,
+						region,
+						append_to_response: "credits",
+					}),
 				enabled: !!collectionData,
 				staleTime: 1000 * 60 * 60,
 			})) || [],

--- a/apps/frontend/src/utils/utils.ts
+++ b/apps/frontend/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import type { Schemas } from "shared";
+
 export type ImageSize = "w200" | "w500" | "original";
 
 export const getTmdbImageUrl = (
@@ -52,3 +54,39 @@ export const getMediaProps = (
 				},
 			};
 };
+
+export function mergeCastMemberCharacters(
+	cast: Array<Schemas.CastMember & { characters?: string[] }>,
+	member: Schemas.CastMember,
+): void {
+	const existing = cast.find((c) => c.id === member.id);
+
+	if (existing) {
+		if (member.character && !existing.characters?.includes(member.character)) {
+			existing.characters = [...(existing.characters || []), member.character];
+		}
+	} else {
+		cast.push({
+			...member,
+			characters: member.character ? [member.character] : [],
+		});
+	}
+}
+
+export function mergeCrewMemberJobs(
+	crew: Array<Schemas.CrewMember & { jobs?: string[] }>,
+	member: Schemas.CrewMember,
+): void {
+	const existing = crew.find((c) => c.id === member.id);
+
+	if (existing) {
+		if (member.job && !existing.jobs?.includes(member.job)) {
+			existing.jobs = [...(existing.jobs || []), member.job];
+		}
+	} else {
+		crew.push({
+			...member,
+			jobs: member.job ? [member.job] : [],
+		});
+	}
+}


### PR DESCRIPTION
rework the layout of the collection page
- remove data about financial results. the data didnt rly make sense especially since there's streaming platform only movies where you cant really know how much they won from it etc
- make the layout similar to movie details: background image at the top, with padding for the content.
- add cast and crew tabs, with roles/jobs merging: so if an actor has multiple characters, every characters will be displayed correctly, same for if a director has other jobs like screenplay.

before:

<img width="1612" height="1029" alt="image" src="https://github.com/user-attachments/assets/2689a903-adf8-48df-8dec-5092ed1bb5ea" />


after:

<img width="1654" height="988" alt="image" src="https://github.com/user-attachments/assets/a9b9e396-bf61-4922-a9a8-780c7064e596" />
